### PR TITLE
Implement M600/M701/M702

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -627,7 +627,11 @@ int Get_Menu_Size(uint8_t menu) {
     case Info:
       return 0;
     case Tune:
-      return 8;
+      #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
+        return 9;
+      #else
+        return 8;
+      #endif
   }
   return 0;
 }
@@ -704,7 +708,11 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
         #if ENABLED(ADVANCED_PAUSE_FEATURE)
           case 8: // Change Filament
             if (draw) {
-              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament", true);
+              #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
+                Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament", true);
+              #else
+                Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
+              #endif
             } else {
               #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
                 Draw_Menu(ChangeFilament);
@@ -987,7 +995,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
             break;
           case 1: // Load Filament
             if (draw) {
-              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Load Filament", true);
+              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Load Filament");
             } else {
               Popup_Window_LoadFilament();
               gcode.process_subcommands_now_P(PSTR("M701"));
@@ -997,7 +1005,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
             break;
           case 2: // Unload Filament
             if (draw) {
-              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Unload Filament", true);
+              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Unload Filament");
             } else {
               Popup_Window_LoadFilament(true);
               gcode.process_subcommands_now_P(PSTR("M702"));
@@ -1007,7 +1015,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
             break;
           case 3: // Change Filament
             if (draw) {
-              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament", true);
+              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
             } else {
               Popup_Window_ChangeFilament();
               gcode.process_subcommands_now_P(PSTR("M600 B1"));
@@ -1636,6 +1644,18 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
             }
           }
           break;
+        #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
+          case 9: // Change Filament
+            if (draw) {
+              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
+            } else {
+              Popup_Window_ChangeFilament();
+              gcode.process_subcommands_now_P(PSTR("M600 B1"));
+              planner.synchronize();
+              Draw_Print_Screen();
+            }
+            break;
+          #endif
       }
       break;
   }

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -54,6 +54,10 @@
 
 #if ENABLED(DWIN_CREALITY_LCD)
 
+#if ENABLED(ADVANCED_PAUSE_FEATURE)
+  #include "../../../feature/pause.h"
+#endif
+
 #if ENABLED(HOST_ACTION_COMMANDS)
   #include "../../../feature/host_actions.h"
 #endif
@@ -2079,6 +2083,9 @@ inline void Popup_Control() {
           Draw_Main_Menu();
         }
         break;
+      case M600:
+        Draw_Menu(Prepare, 8);
+        break;
     }
   DWIN_UpdateLCD();
 }
@@ -2090,9 +2097,6 @@ inline void Confirm_Control() {
     switch(popup) {
       case Complete:
         Draw_Main_Menu();
-        break;
-      case M600:
-        Draw_Menu(Prepare, 8);
         break;
     }
   }
@@ -2321,12 +2325,10 @@ inline void HMI_SDCardInit() { card.cdroot(); }
 void MarlinUI::refresh() {}
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
-  #include "../../../feature/pause.h"
-
   void MarlinUI::pause_show_message(const PauseMessage message, const PauseMode mode, const uint8_t extruder) {
     // TODO implement remainder of PauseMessage states
     if (message == PAUSE_MESSAGE_INSERT || message == PAUSE_MESSAGE_WAITING) {
-      process = Confirm;
+      process = Popup;
       popup = M600;
       Clear_Screen();
 

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -707,6 +707,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
               #else
                 queue.inject_P(PSTR("M600"));
                 // TODO change filament popup
+                Draw_Menu(Prepare, 8);
               #endif
             }
             break;
@@ -986,6 +987,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
               Popup_Window_LoadFilament();
               gcode.process_subcommands_now_P(PSTR("M701"));
               planner.synchronize();
+              Draw_Menu(Prepare, 8);
             }
             break;
           case 2: // Unload Filament
@@ -995,6 +997,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
               Popup_Window_LoadFilament(true);
               gcode.process_subcommands_now_P(PSTR("M702"));
               planner.synchronize();
+              Draw_Menu(Prepare, 8);
             }
             break;
           case 3: // Change Filament
@@ -1003,6 +1006,7 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
             } else {
               queue.inject_P(PSTR("M600"));
               // TODO change filament popup
+              Draw_Menu(Prepare, 8);
             }
             break;
         }

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -46,6 +46,7 @@ enum menuID : uint8_t {
       ManualLevel,
       ZOffset,
       Preheat,
+      ChangeFilament,
     Control,
       TempMenu,
         Preheat1,
@@ -228,6 +229,14 @@ void Popup_Window_Move();
 void Popup_window_Pause();
 void Popup_window_Stop();
 void Popup_window_SaveLevel();
+
+#if ENABLED(ADVANCED_PAUSE_FEATURE)
+  //  void Popup_Window_ChangeFilament(); // TODO
+
+  #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
+    void Popup_Window_LoadFilament(const bool unloading=false);
+  #endif
+#endif
 
 
 inline void Main_Menu_Control();

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -36,7 +36,7 @@ enum processID : uint8_t {
 };
 
 enum popupID : uint8_t {
-  Pause, Stop, Resume, ETemp, Level, Complete
+  Pause, Stop, Resume, ETemp, Level, Complete, M600
 };
 
 enum menuID : uint8_t {
@@ -231,7 +231,7 @@ void Popup_window_Stop();
 void Popup_window_SaveLevel();
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
-  //  void Popup_Window_ChangeFilament(); // TODO
+  void Popup_Window_ChangeFilament();
 
   #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
     void Popup_Window_LoadFilament(const bool unloading=false);

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -51,7 +51,7 @@
   #include "../module/printcounter.h"
 #endif
 
-#if BOTH(HAS_LCD_MENU, ADVANCED_PAUSE_FEATURE)
+#if BOTH(HAS_LCD_MENU, ADVANCED_PAUSE_FEATURE) || BOTH(DWIN_CREALITY_LCD, ADVANCED_PAUSE_FEATURE)
   #include "../feature/pause.h"
   #include "../module/motion.h" // for active_extruder
 #endif
@@ -498,7 +498,7 @@ public:
 
   #endif
 
-  #if BOTH(HAS_LCD_MENU, ADVANCED_PAUSE_FEATURE)
+  #if BOTH(HAS_LCD_MENU, ADVANCED_PAUSE_FEATURE) || BOTH(DWIN_CREALITY_LCD, ADVANCED_PAUSE_FEATURE)
     static void pause_show_message(const PauseMessage message, const PauseMode mode=PAUSE_MODE_SAME, const uint8_t extruder=active_extruder);
   #else
     static inline void _pause_show_message() {}


### PR DESCRIPTION
Includes a wait popup for Load/Unload but M600 is non-blocking so not sure how to do the two stage popup required there.
Where right after M600 the user is to wait for heat up + unloading, then when ready it turns into a confirm prompt for the user to initiate Load.

It may also need to be hooked up to temp checking, in my experience it auto-heats to min extrusion temperature when you run M600/M701/M702 so is a non-issue.

![image](https://user-images.githubusercontent.com/2403652/106343309-99d18f00-629c-11eb-96b9-77e0eaae644e.png)
![image](https://user-images.githubusercontent.com/2403652/106343316-9d651600-629c-11eb-8e6e-6f3f9d68bb06.png)
![image](https://user-images.githubusercontent.com/2403652/106343318-9fc77000-629c-11eb-8212-c0057db807d2.png)
