### PR TITLE
Correct the menu Max Jerk which is not showing/modifying decimals

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -1697,38 +1697,38 @@ void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/*=true*/) {
         case JERK_X:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxSpeedJerkX, (char*)"X Axis");
-            Draw_Float(planner.max_jerk[X_AXIS], row, false, 1);
+            Draw_Float(planner.max_jerk[X_AXIS], row, false, 10);
           }
           else {
-            Modify_Value(planner.max_jerk[X_AXIS], 0, default_max_jerk[X_AXIS]*2, 1);
+            Modify_Value(planner.max_jerk[X_AXIS], 0, default_max_jerk[X_AXIS]*2, 10);
           }
           break;
         case JERK_Y:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxSpeedJerkY, (char*)"Y Axis");
-            Draw_Float(planner.max_jerk[Y_AXIS], row, false, 1);
+            Draw_Float(planner.max_jerk[Y_AXIS], row, false, 10);
           }
           else {
-            Modify_Value(planner.max_jerk[Y_AXIS], 0, default_max_jerk[Y_AXIS]*2, 1);
+            Modify_Value(planner.max_jerk[Y_AXIS], 0, default_max_jerk[Y_AXIS]*2, 10);
           }
           break;
         case JERK_Z:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, (char*)"Z Axis");
-            Draw_Float(planner.max_jerk[Z_AXIS], row, false, 1);
+            Draw_Float(planner.max_jerk[Z_AXIS], row, false, 10);
           }
           else {
-            Modify_Value(planner.max_jerk[Z_AXIS], 0, default_max_jerk[Z_AXIS]*2, 1);
+            Modify_Value(planner.max_jerk[Z_AXIS], 0, default_max_jerk[Z_AXIS]*2, 10);
           }
           break;
         #if HAS_HOTEND
         case JERK_E:
           if (draw) {
             Draw_Menu_Item(row, ICON_MaxSpeedJerkE, (char*)"Extruder");
-            Draw_Float(planner.max_jerk[E_AXIS], row, false, 1);
+            Draw_Float(planner.max_jerk[E_AXIS], row, false, 10);
           }
           else {
-            Modify_Value(planner.max_jerk[E_AXIS], 0, default_max_jerk[E_AXIS]*2, 1);
+            Modify_Value(planner.max_jerk[E_AXIS], 0, default_max_jerk[E_AXIS]*2, 10);
           }
           break;
         #endif


### PR DESCRIPTION
Correct the bug with menu Max Jerk which isn't showing/modifying decimals (it's a must for Jerks).

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Corrected menu MAX Jerk which not showing and permit changing decimals values. Nothing else modified.

-->

### Related Issues

<!-- FIX Max Jerk Menu decimals -->
