### PR TITLE
Upgrade to compile with the latest ST STM32 platform vs 11.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -212,7 +212,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
+build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -767,7 +767,8 @@ lib_deps          = ${common.lib_deps}
   SoftwareSerialM
 platform_packages = tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
-  buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+# depends on https://github.com/MarlinFirmware/Marlin/pull/20492
+#  buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
 
 #
 # STM32F103RC

--- a/platformio.ini
+++ b/platformio.ini
@@ -212,17 +212,20 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
+build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
 #
 # Feature Dependencies
 #
 [features]
+YHCB2004                = red-scorp/LiquidCrystal_AIP31068@^1.0.4, red-scorp/SoftSPIB@^1.1.1
 HAS_TFT_LVGL_UI         = lvgl=https://github.com/makerbase-mks/LVGL-6.1.1-MKS/archive/master.zip
                           src_filter=+<src/lcd/extui/lib/mks_ui>
                           extra_scripts=download_mks_assets.py
 MKS_WIFI_MODULE         = QRCode=https://github.com/makerbase-mks/QRCode/archive/master.zip
+POSTMORTEM_DEBUGGING    = src_filter=+<src/HAL/shared/cpu_exception> +<src/HAL/shared/backtrace>
+                          build_flags=-funwind-tables
 HAS_TRINAMIC_CONFIG     = TMCStepper@~0.7.1
                           src_filter=+<src/feature/tmc_util.cpp> +<src/module/stepper/trinamic.cpp> +<src/gcode/feature/trinamic/M122.cpp> +<src/gcode/feature/trinamic/M906.cpp> +<src/gcode/feature/trinamic/M911-M914.cpp>
 HAS_STEALTHCHOP         = src_filter=+<src/gcode/feature/trinamic/M569.cpp>
@@ -763,6 +766,8 @@ lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM
 platform_packages = tool-stm32duino
+extra_scripts     = ${common.extra_scripts}
+  buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
 
 #
 # STM32F103RC
@@ -788,7 +793,7 @@ build_flags       = ${common_stm32f1.build_flags}
                     -DUSE_USB_COMPOSITE
                     -DVECT_TAB_OFFSET=0x2000
                     -DGENERIC_BOOTLOADER
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/STM32F103RC_MEEB_3DP.py
 lib_deps          = ${common.lib_deps}
@@ -804,7 +809,7 @@ upload_protocol   = dfu
 [env:STM32F103RC_fysetc]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0
 lib_ldf_mode      = chain
@@ -828,7 +833,7 @@ upload_protocol   = serial
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
@@ -870,7 +875,7 @@ monitor_speed     = 115200
 [env:STM32F103RE_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RE
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0 -DSS_TIMER=4
 debug_tool        = stlink
@@ -1195,7 +1200,7 @@ board             = STEVAL_STM32F401VE
 build_flags       = ${common_stm32.build_flags}
   -DARDUINO_STEVAL -DSTM32F401xE
   -DDISABLE_GENERIC_SERIALUSB -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/STEVAL__F401XX.py
 
@@ -1207,7 +1212,7 @@ platform          = ${common_stm32.platform}
 extends           = common_stm32
 board             = FYSETC_CHEETAH_V20
 build_flags       = ${common_stm32.build_flags} -DSTM32F401xC -DVECT_TAB_OFFSET=0xC000
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/FYSETC_CHEETAH_V20.py
 
@@ -1230,7 +1235,7 @@ extra_scripts     = ${common.extra_scripts}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
  buildroot/share/PlatformIO/scripts/fly_mini.py
 build_flags       = ${common_stm32f1.build_flags}
  -DDEBUG_LEVEL=0 -DSS_TIMER=4
@@ -1246,7 +1251,7 @@ board             = marlin_fysetc_s6
 build_flags       = ${common_stm32.build_flags}
   -DVECT_TAB_OFFSET=0x10000
   -DHAL_PCD_MODULE_ENABLED
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 debug_tool        = stlink
 upload_protocol   = dfu
@@ -1264,7 +1269,7 @@ board             = blackSTM32F407VET6
 build_flags       = ${common_stm32.build_flags}
   -DARDUINO_BLACK_F407VE
   -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 
 #
@@ -1281,7 +1286,7 @@ board_build.core     = stm32
 board_build.variant  = MARLIN_F4x7Vx
 board_build.ldscript = ldscript.ld
 board_build.firmware = firmware.srec
-# Just anet_et4_openblt.py generates the file, not stm32_bootloader.py
+# Just openblt.py (not stm32_bootloader.py) generates the file
 board_build.encrypt  = Yes
 board_build.offset   = 0x10000
 board_upload.offset_address = 0x08010000
@@ -1291,7 +1296,7 @@ upload_protocol      = jlink
 extra_scripts        = ${common.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
-  buildroot/share/PlatformIO/scripts/anet_et4_openblt.py
+  buildroot/share/PlatformIO/scripts/openblt.py
 
 #
 # BigTreeTech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
@@ -1302,7 +1307,7 @@ extends           = common_stm32
 board             = BigTree_SKR_Pro
 build_flags       = ${common_stm32.build_flags}
   -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 #upload_protocol   = stlink
 #upload_command    = "$PROJECT_PACKAGES_DIR/tool-stm32duino/stlink/ST-LINK_CLI.exe" -c SWD -P "$BUILD_DIR/firmware.bin" 0x8008000 -Rst -Run
@@ -1333,7 +1338,7 @@ build_flags       = ${stm32_flash_drive.build_flags}
 platform          = ${common_stm32.platform}
 extends           = common_stm32
 board             = BigTree_GTR_v1
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 build_flags       = ${common_stm32.build_flags}
   -DSTM32F407IX -DVECT_TAB_OFFSET=0x8000
@@ -1359,7 +1364,7 @@ build_flags       = ${common_stm32.build_flags}
   -DHAVE_HWSERIAL3
   -DPIN_SERIAL2_RX=PD_6
   -DPIN_SERIAL2_TX=PD_5
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -739,7 +739,7 @@ board    = nxp_lpc1769
 # HAL/STM32 Base Environment values
 #
 [common_stm32]
-platform      = ststm32@~10.0
+platform      = ststm32@~11.0
 build_flags   = ${common.build_flags}
   -std=gnu++14
   -DUSBCON -DUSBD_USE_CDC
@@ -752,7 +752,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/b
 # HAL/STM32F1 Common Environment values
 #
 [common_stm32f1]
-platform          = ststm32@~10.0
+platform          = ststm32@~11.0
 board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}


### PR DESCRIPTION
### Requirements

PlatformIO ST STM32 platform vs 11.0

### Description

Upgrade to compile with the ST STM32 platform vs 11.0

### Benefits

Newest and lastest platform for the SoC.

### Configurations

As proposed.

### Related Issues

N/A.
