### PR TITLE
Further code compiling optimization O2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -212,7 +212,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
+build_flags        = -fmax-errors=5 -g -O2 -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -757,7 +757,7 @@ board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}
   -DARDUINO_ARCH_STM32
-build_unflags     = -std=gnu11 -std=gnu++11
+build_unflags     = -std=gnu11 -std=gnu++11 -Os
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}


### PR DESCRIPTION
### Requirements

GCC installed, along with PlatformIO.

### Description

Allow the compiler to improve the code execution speed, through further moderate low-level code optimization.

### Benefits

A probably faster code execution on the STM32F1 SoC, with its limited 72 MHz core frequency. Leading to a much lower probability of buffer overrun under high speed printing scenarios.

### Configurations

```
platform.io

[common.build_flags]        = -fmax-errors=5 -g -O2 -D__MARLIN_FIRMWARE__ -fmerge-constants
```


### Related Issues

N/A.
