### PR TITLE
Change Filament menu item now throws a warning message if nozzle is b…

### DIFF
--- a/Marlin/src/lcd/extui/lib/creality_dwin/creality_dwin.cpp
+++ b/Marlin/src/lcd/extui/lib/creality_dwin/creality_dwin.cpp
@@ -820,10 +820,15 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
                 Draw_Menu(ChangeFilament);
               #else
+                if (thermalManager.temp_hotend[0].celsius < EXTRUDE_MINTEMP) {
+                Popup_Handler(ChangeFilTempWarn);
+                }
+                else {
                 Popup_Handler(FilChange);
                 gcode.process_subcommands_now_P(PSTR("M600 B1"));
                 planner.synchronize();
                 Redraw_Menu();
+                }               
               #endif
             }
             break;
@@ -1263,10 +1268,15 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
             }
             else {
-              Popup_Handler(FilChange);
-              gcode.process_subcommands_now_P(PSTR("M600 B1"));
-              planner.synchronize();
-              Redraw_Menu();
+              if (thermalManager.temp_hotend[0].celsius < EXTRUDE_MINTEMP) {
+                Popup_Handler(ChangeFilTempWarn);
+              }
+              else {
+                Popup_Handler(FilChange);
+                gcode.process_subcommands_now_P(PSTR("M600 B1"));
+                planner.synchronize();
+                Redraw_Menu();
+              }
             }
             break;
         }
@@ -2617,6 +2627,11 @@ void CrealityDWINClass::Popup_Handler(uint8_t popupid, bool option/*=false*/) {
       break;
     case PidDone:
       Draw_Popup((char*)"PID tuning done", (char*)"", (char*)"", Confirm, ICON_BLTouch);
+      break;
+    case ChangeFilTempWarn:
+      popup = UI;
+      last_process = Menu;
+      Draw_Popup((char*)"", (char*)"Nozzle temp too low!", (char*)"Preheat First!", Confirm, ICON_TempTooLow);
       break;
   }
 }

--- a/Marlin/src/lcd/extui/lib/creality_dwin/creality_dwin.h
+++ b/Marlin/src/lcd/extui/lib/creality_dwin/creality_dwin.h
@@ -36,7 +36,7 @@ enum processID : uint8_t {
 };
 
 enum popupID : uint8_t {
-  Pause, Stop, Resume, SaveLevel, ETemp, Level, Home, MoveWait, Complete, FilLoad, FilChange, UI, TempWarn, Runout, PidBadExtruder, PidTimeout, PidDone
+  Pause, Stop, Resume, SaveLevel, ETemp, Level, Home, MoveWait, Complete, FilLoad, FilChange, UI, TempWarn, Runout, PidBadExtruder, PidTimeout, PidDone, ChangeFilTempWarn
 };
 
 enum menuID : uint8_t {


### PR DESCRIPTION
…elow EXTRUDE_MINTEMP.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

By default, the Change Filament menu item just sends a M600 command.  However, the M600 command relies on the extruder already being at the correct print temp, and silently ignores the unload command because it can't do a cold retract.  Then it goes on to preheat before the filament load.  This popup warning will let people know they need to preheat the extruder to the correct temp, that way the initial filament unload will work.

-->