### PR TITLE
Define a different baud rate setting for LCD

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2384,7 +2384,7 @@
   //
   // Force a maximum 115200 bitrate for the Ender 3 V2 OEM LCD, independently from the one of Creality board.
   //
-  #define E3V2_LCD_BAUDRATE 115200
+  #define LCD_BAUDRATE 115200
 #endif
 
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2380,6 +2380,11 @@
   // NB: Requires Ender-3 v2 OEM display firmware update, or you will get blank icons!
   //
   //#define CREALITY_DWIN_EXTUI_CUSTOM_ICONS
+  //#define CREALITY_DWIN_EXTUI_CUSTOM_ICONS
+  //
+  // Force a maximum 115200 bitrate for the Ender 3 V2 OEM LCD, independently from the one of Creality board.
+  //
+  #define E3V2_LCD_BAUDRATE 115200
 #endif
 
 //

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1063,7 +1063,12 @@ void setup() {
   #endif
   #define SETUP_RUN(C) do{ SETUP_LOG(STRINGIFY(C)); C; }while(0)
 
-  MYSERIAL1.begin(BAUDRATE);
+  #if ENABLED(E3V2_LCD_BAUDRATE)
+    MYSERIAL1.begin(E3V2_LCD_BAUDRATE);
+  #else
+    MYSERIAL1.begin(BAUDRATE);
+  #endif
+                    
   millis_t serial_connect_timeout = millis() + 1000UL;
   while (!MYSERIAL1.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1063,8 +1063,8 @@ void setup() {
   #endif
   #define SETUP_RUN(C) do{ SETUP_LOG(STRINGIFY(C)); C; }while(0)
 
-  #if ENABLED(E3V2_LCD_BAUDRATE)
-    MYSERIAL1.begin(E3V2_LCD_BAUDRATE);
+  #if ENABLED(LCD_BAUDRATE)
+    MYSERIAL1.begin(LCD_BAUDRATE);
   #else
     MYSERIAL1.begin(BAUDRATE);
   #endif


### PR DESCRIPTION
### Requirements

N/A

### Description

Many users want to have a higher USB communication baud rate, aiming better SD card transfer speeds and lower the risk of buffer overrun leading to reduced printing performance, when printing from an external host (such as octoprint or PC).

The Ender 3 V2 OEM LCD seems to have an upper limit of 115200 bits/s, instead the 250000 bits/sec of OEM Creality 4.2.2 boards: https://www.reddit.com/r/ender3/comments/ihg2k7/dwin_display_on_ender3_v2_does_not_work_with_a/

### Benefits

Setting different baud rates. One for the board/standard (115200 or 250000, e.g.) and another one for the LCD (115200, e.g.).

### Configurations

N/A.

### Related Issues
