### PR TITLE
Enabling KILL_PIN on Z endstop pin

### DIFF
--- a/Configuration Files/Jyers's Config/Configuration.h
+++ b/Configuration Files/Jyers's Config/Configuration.h
@@ -904,6 +904,13 @@
  */
 //#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
+//
+// See http://technologybob.co.uk/configuring-marlin-for-ender-3-v2
+//
+#define KILL_PIN PA7
+#define KILL_PIN_STATE HIGH
+
+
 // Force the use of the probe for Z-axis homing
 #define USE_PROBE_FOR_Z_HOMING
 


### PR DESCRIPTION
### Requirements

A free Z endstop pin.

### Description

I'm submitting just for testing purposes, as this functionality is not documented (AFAIK) at marlinfw.org.

### Benefits

This "kill pin" is able to stop the printer in a emergency, using the spare z endstop pin/switch for this kind of trigger.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

N/A
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
