### PR TITLE
Fixing E0 current value

### DIFF
--- a/Configuration Files/Jyers's Config/Configuration_adv.h
+++ b/Configuration Files/Jyers's Config/Configuration_adv.h
@@ -2479,7 +2479,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT      800
+    #define E0_CURRENT      990
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1
@@ -2487,7 +2487,7 @@
   #endif
 
   #if AXIS_IS_TMC(E1)
-    #define E1_CURRENT      990
+    #define E1_CURRENT      800
     #define E1_MICROSTEPS    E0_MICROSTEPS
     #define E1_RSENSE         0.11
     #define E1_CHAIN_POS     -1


### PR DESCRIPTION
### Requirements
N/A

### Description
I'm assuming there is an error on the E0 vs E1 current values, since the Ender 3 V2 only has one extruder stepper driver.

### Benefits

Ajusting the correct extruder motor current.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
