### PR TITLE
Enabling G29_RETRY_AND_RECOVER for stubborn BLTouch on 4.2.2 boards

### DIFF
--- a/Configuration Files/E3V2 Templates/BLTouch-3x3-HighSpeed/Configuration_adv.h
+++ b/Configuration Files/E3V2 Templates/BLTouch-3x3-HighSpeed/Configuration_adv.h
@@ -1843,9 +1843,9 @@
  * Repeatedly attempt G29 leveling until it succeeds.
  * Stop after G29_MAX_RETRIES attempts.
  */
-//#define G29_RETRY_AND_RECOVER
+#define G29_RETRY_AND_RECOVER
 #if ENABLED(G29_RETRY_AND_RECOVER)
-  #define G29_MAX_RETRIES 3
+  #define G29_MAX_RETRIES 4
   #define G29_HALT_ON_FAILURE
   /**
    * Specify the GCODE commands that will be executed when leveling succeeds,

--- a/Configuration Files/E3V2 Templates/BLTouch-3x3/Configuration_adv.h
+++ b/Configuration Files/E3V2 Templates/BLTouch-3x3/Configuration_adv.h
@@ -1843,9 +1843,9 @@
  * Repeatedly attempt G29 leveling until it succeeds.
  * Stop after G29_MAX_RETRIES attempts.
  */
-//#define G29_RETRY_AND_RECOVER
+#define G29_RETRY_AND_RECOVER
 #if ENABLED(G29_RETRY_AND_RECOVER)
-  #define G29_MAX_RETRIES 3
+  #define G29_MAX_RETRIES 4
   #define G29_HALT_ON_FAILURE
   /**
    * Specify the GCODE commands that will be executed when leveling succeeds,


### PR DESCRIPTION
### Requirements

- BLtouch connected to the 5 pins socket on the Creality 4.2.2 boards.
- Enabled `AUTO_BED_LEVELING_BILINEAR`
- UBL **seems** to be **NOT** compatible with this. _(why?!)_

### Description

Many users suffer from the classical issue of random probing failure with 4.2.2 boards and BLTouch connected to the 5 pin socket.

### Benefits

Gracefully detects a probing error and restarts the bed probing (up to 4 times), from the beginning. Avoiding going straight to print without a full new mesh generated.

This is not a permanent fix, instead just a plain workaround, aiming a much more graceful way to correct the consequences of an erroneous mesh caused by a single point probe failure.

### Configurations

```#define G29_RETRY_AND_RECOVER```

### Related Issues

Lots of them, across the web.
