### PR TITLE
Refactor: Constify char pointers

### DIFF
--- a/Marlin/src/lcd/dwin/creality_dwin.cpp
+++ b/Marlin/src/lcd/dwin/creality_dwin.cpp
@@ -411,7 +411,7 @@ inline void CrealityDWINClass::Draw_Float(float value, uint8_t row, bool selecte
   }
 }
 
-inline void CrealityDWINClass::Draw_Option(uint8_t value, char** options, uint8_t row, bool selected/*=false*/, bool color/*=false*/) {
+inline void CrealityDWINClass::Draw_Option(uint8_t value, const char * const * options, uint8_t row, bool selected/*=false*/, bool color/*=false*/) {
   uint16_t bColor = (selected) ? Select_Color : Color_Bg_Black;
   uint16_t tColor = (color) ? GetColor(value, Color_White, false) : Color_White;
   DWIN_Draw_Rectangle(1, bColor, 202, MBASE(row) + 14, 258, MBASE(row) - 2);
@@ -457,11 +457,11 @@ inline uint16_t CrealityDWINClass::GetColor(uint8_t color, uint16_t original, bo
   return Color_White;
 }
 
-inline void CrealityDWINClass::Draw_Title(char *title) {
+inline void CrealityDWINClass::Draw_Title(const char *title) {
   DWIN_Draw_String(false, false, DWIN_FONT_HEAD, GetColor(eeprom_settings.menu_top_txt, Color_White, false), Color_Bg_Blue, (DWIN_WIDTH - strlen(title) * STAT_CHR_W) / 2, 5, title);
 }
 
-inline void CrealityDWINClass::Draw_Menu_Item(uint8_t row, uint8_t icon/*=0*/, char *label1, char *label2, bool more/*=false*/, bool centered/*=false*/) {
+inline void CrealityDWINClass::Draw_Menu_Item(uint8_t row, uint8_t icon/*=0*/, const char *label1, const char *label2, bool more/*=false*/, bool centered/*=false*/) {
   const uint8_t label_offset_y = !(label1 && label2) ? 0 : MENU_CHR_H * 3 / 5;
   const uint8_t label1_offset_x = !centered ? LBLX : LBLX * 4/5 + max(LBLX * 1U/5, (DWIN_WIDTH - LBLX - (label1 ? strlen(label1) : 0) * MENU_CHR_W) / 2);
   const uint8_t label2_offset_x = !centered ? LBLX : LBLX * 4/5 + max(LBLX * 1U/5, (DWIN_WIDTH - LBLX - (label2 ? strlen(label2) : 0) * MENU_CHR_W) / 2);
@@ -634,12 +634,12 @@ void CrealityDWINClass::Draw_Print_Screen() {
   selection = 0;
   Clear_Screen();
   DWIN_Draw_Rectangle(1, Color_Bg_Black, 8, 352, DWIN_WIDTH-8, 376);
-  Draw_Title((char*)"Printing...");
+  Draw_Title("Printing...");
   Print_Screen_Icons();
   DWIN_ICON_Show(ICON, ICON_PrintTime, 14, 171);
   DWIN_ICON_Show(ICON, ICON_RemainTime, 147, 169);
-  DWIN_Draw_String(false, false, DWIN_FONT_MENU, Color_White, Color_Bg_Black, 41, 163, (char*)"Elapsed");
-  DWIN_Draw_String(false, false, DWIN_FONT_MENU,  Color_White, Color_Bg_Black, 176, 163, (char*)"Remaining");
+  DWIN_Draw_String(false, false, DWIN_FONT_MENU, Color_White, Color_Bg_Black, 41, 163, "Elapsed");
+  DWIN_Draw_String(false, false, DWIN_FONT_MENU,  Color_White, Color_Bg_Black, 176, 163, "Remaining");
   Update_Status_Bar(true);
   Draw_Print_ProgressBar();
   Draw_Print_ProgressElapsed();
@@ -687,7 +687,7 @@ void CrealityDWINClass::Draw_Print_ProgressBar() {
   DWIN_ICON_Show(ICON, ICON_Bar, 15, 93);
   DWIN_Draw_Rectangle(1, BarFill_Color, 16 + printpercent * 240 / 100, 93, 256, 113);
   DWIN_Draw_IntValue(true, true, 0, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_percent, Percent_Color), Color_Bg_Black, 3, 109, 133, printpercent);
-  DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_percent, Percent_Color), Color_Bg_Black, 133, 133, (char*)"%");
+  DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_percent, Percent_Color), Color_Bg_Black, 133, 133, "%");
 }
 
 void CrealityDWINClass::Draw_Print_ProgressRemain() {
@@ -695,11 +695,11 @@ void CrealityDWINClass::Draw_Print_ProgressRemain() {
   DWIN_Draw_IntValue(true, true, 1, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 2, 176, 187, remainingtime / 3600);
   DWIN_Draw_IntValue(true, true, 1, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 2, 200, 187, (remainingtime % 3600) / 60);
   if (eeprom_settings.time_format_textual) {
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 192, 187, (char*)"h");
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 216, 187, (char*)"m");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 192, 187, "h");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 216, 187, "m");
   }
   else {
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 192, 187, (char*)":");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 192, 187, ":");
   }
 }
 
@@ -708,11 +708,11 @@ void CrealityDWINClass::Draw_Print_ProgressElapsed() {
   DWIN_Draw_IntValue(true, true, 1, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 2, 42, 187, elapsed.value / 3600);
   DWIN_Draw_IntValue(true, true, 1, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 2, 66, 187, (elapsed.value % 3600) / 60);
   if (eeprom_settings.time_format_textual) {
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 58, 187, (char*)"h");
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 82, 187, (char*)"m");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 58, 187, "h");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 82, 187, "m");
   }
   else {
-    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 58, 187, (char*)":");
+    DWIN_Draw_String(false, false, DWIN_FONT_MENU, GetColor(eeprom_settings.progress_time, Color_White), Color_Bg_Black, 58, 187, ":");
   }
 }
 
@@ -729,9 +729,9 @@ void CrealityDWINClass::Draw_Print_confirm() {
 void CrealityDWINClass::Draw_SD_Item(uint8_t item, uint8_t row) {
   if (item == 0) {
     if (card.flag.workDirIsRoot)
-      Draw_Menu_Item(0, ICON_Back, (char*)"Back");
+      Draw_Menu_Item(0, ICON_Back, "Back");
     else
-      Draw_Menu_Item(0, ICON_Back, (char*)"..");
+      Draw_Menu_Item(0, ICON_Back, "..");
   }
   else {
     card.getfilename_sorted(SD_ORDER(item-1, card.get_num_Files()));
@@ -753,7 +753,7 @@ void CrealityDWINClass::Draw_SD_Item(uint8_t item, uint8_t row) {
 
 void CrealityDWINClass::Draw_SD_List(bool removed/*=false*/) {
   Clear_Screen();
-  Draw_Title((char*)"Select File");
+  Draw_Title("Select File");
   selection = 0;
   scrollpos = 0;
   process = File;
@@ -762,9 +762,9 @@ void CrealityDWINClass::Draw_SD_List(bool removed/*=false*/) {
       Draw_SD_Item(i, i);
   }
   else {
-    Draw_Menu_Item(0, ICON_Back, (char*)"Back");
+    Draw_Menu_Item(0, ICON_Back, "Back");
     DWIN_Draw_Rectangle(1, Color_Bg_Red, 10, MBASE(3) - 10, DWIN_WIDTH - 10, MBASE(4));
-    DWIN_Draw_String(false, false, font16x32, Color_Yellow, Color_Bg_Red, ((DWIN_WIDTH) - 8 * 16) / 2, MBASE(3), (char*)"No Media");
+    DWIN_Draw_String(false, false, font16x32, Color_Yellow, Color_Bg_Red, ((DWIN_WIDTH) - 8 * 16) / 2, MBASE(3), "No Media");
   }
   DWIN_Draw_Rectangle(1, GetColor(eeprom_settings.cursor_color, Rectangle_Color), 0, MBASE(0) - 18, 14, MBASE(0) + 33);
 }
@@ -848,11 +848,11 @@ void CrealityDWINClass::Draw_Status_Area(bool icons/*=false*/) {
       offset = zoffsetvalue;
       if (zoffsetvalue < 0) {
         DWIN_Draw_FloatValue(true, true, 0, DWIN_FONT_STAT, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 2, 2, 207, 417, -zoffsetvalue * 100);
-        DWIN_Draw_String(false, true, DWIN_FONT_MENU, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 205, 419, (char*)"-");
+        DWIN_Draw_String(false, true, DWIN_FONT_MENU, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 205, 419, "-");
       }
       else {
         DWIN_Draw_FloatValue(true, true, 0, DWIN_FONT_STAT, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 2, 2, 207, 417, zoffsetvalue* 100);
-        DWIN_Draw_String(false, true, DWIN_FONT_MENU, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 205, 419, (char*)" ");
+        DWIN_Draw_String(false, true, DWIN_FONT_MENU, GetColor(eeprom_settings.status_area_text, Color_White), Color_Bg_Black, 205, 419, " ");
       }
     }
   #endif
@@ -1010,7 +1010,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case PREPARE_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Main_Menu(1);
@@ -1018,7 +1018,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case PREPARE_MOVE:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Axis, (char*)"Move", NULL, true);
+            Draw_Menu_Item(row, ICON_Axis, "Move", NULL, true);
           }
           else {
             Draw_Menu(Move);
@@ -1026,7 +1026,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case PREPARE_DISABLE:
           if (draw) {
-            Draw_Menu_Item(row, ICON_CloseMotor, (char*)"Disable Stepper");
+            Draw_Menu_Item(row, ICON_CloseMotor, "Disable Stepper");
           }
           else {
             queue.inject_P(PSTR("M84"));
@@ -1034,7 +1034,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case PREPARE_HOME:
           if (draw) {
-            Draw_Menu_Item(row, ICON_SetHome, (char*)"Homing", NULL, true);
+            Draw_Menu_Item(row, ICON_SetHome, "Homing", NULL, true);
           }
           else {
             Draw_Menu(HomeMenu);
@@ -1042,7 +1042,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case PREPARE_MANUALLEVEL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_PrintSize, (char*)"Manual Leveling", NULL, true);
+            Draw_Menu_Item(row, ICON_PrintSize, "Manual Leveling", NULL, true);
           }
           else {
             if (axes_should_home()) {
@@ -1059,7 +1059,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_ZOFFSET_ITEM
           case PREPARE_ZOFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Zoffset, (char*)"Z-Offset", NULL, true);
+              Draw_Menu_Item(row, ICON_Zoffset, "Z-Offset", NULL, true);
             }
             else {
               #if HAS_LEVELING
@@ -1073,7 +1073,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_PREHEAT
           case PREPARE_PREHEAT:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Temperature, (char*)"Preheat", NULL, true);
+              Draw_Menu_Item(row, ICON_Temperature, "Preheat", NULL, true);
             }
             else {
               Draw_Menu(Preheat);
@@ -1081,7 +1081,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case PREPARE_COOLDOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Cool, (char*)"Cooldown");
+              Draw_Menu_Item(row, ICON_Cool, "Cooldown");
             } 
             else {
               thermalManager.zero_fan_speeds();
@@ -1093,9 +1093,9 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           case PREPARE_CHANGEFIL:
             if (draw) {
               #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
-                Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament", NULL, true);
+                Draw_Menu_Item(row, ICON_ResumeEEPROM, "Change Filament", NULL, true);
               #else
-                Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
+                Draw_Menu_Item(row, ICON_ResumeEEPROM, "Change Filament");
               #endif
             }
             else {
@@ -1135,7 +1135,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch(item) {
         case HOME_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Prepare, PREPARE_HOME);
@@ -1143,7 +1143,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOME_ALL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Homing, (char*)"Home All");
+            Draw_Menu_Item(row, ICON_Homing, "Home All");
           }
           else {
             Popup_Handler(Home);
@@ -1153,7 +1153,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOME_X:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveX, (char*)"Home X");
+            Draw_Menu_Item(row, ICON_MoveX, "Home X");
           }
           else {
             Popup_Handler(Home);
@@ -1164,7 +1164,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOME_Y:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveY, (char*)"Home Y");
+            Draw_Menu_Item(row, ICON_MoveY, "Home Y");
           }
           else {
             Popup_Handler(Home);
@@ -1175,7 +1175,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOME_Z:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveZ, (char*)"Home Z");
+            Draw_Menu_Item(row, ICON_MoveZ,"Home Z");
           }
           else {
             Popup_Handler(Home);
@@ -1186,7 +1186,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOME_SET:
           if (draw) {
-            Draw_Menu_Item(row, ICON_SetHome, (char*)"Set Home Position");
+            Draw_Menu_Item(row, ICON_SetHome, "Set Home Position");
           }
           else {
             gcode.process_subcommands_now_P(PSTR("G92 X0 Y0 Z0"));
@@ -1209,7 +1209,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case MOVE_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             #if HAS_BED_PROBE
@@ -1221,7 +1221,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOVE_X:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveX, (char*)"Move X");
+            Draw_Menu_Item(row, ICON_MoveX, "Move X");
             Draw_Float(current_position.x, row, false);
           }
           else {
@@ -1230,7 +1230,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOVE_Y:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveY, (char*)"Move Y");
+            Draw_Menu_Item(row, ICON_MoveY, "Move Y");
             Draw_Float(current_position.y, row);
           }
           else {
@@ -1239,7 +1239,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOVE_Z:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MoveZ, (char*)"Move Z");
+            Draw_Menu_Item(row, ICON_MoveZ, "Move Z");
             Draw_Float(current_position.z, row);
           }
           else {
@@ -1249,7 +1249,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case MOVE_E:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Extruder, (char*)"Extruder");
+              Draw_Menu_Item(row, ICON_Extruder, "Extruder");
               current_position.e = 0;
               sync_plan_position();
               Draw_Float(current_position.e, row);
@@ -1274,7 +1274,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_BED_PROBE
           case MOVE_P:
             if (draw) {
-              Draw_Menu_Item(row, ICON_StockConfiguraton, (char*)"Probe");
+              Draw_Menu_Item(row, ICON_StockConfiguraton, "Probe");
               Draw_Checkbox(row, probe_deployed);
             }
             else {
@@ -1286,7 +1286,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #endif
         case MOVE_LIVE:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Axis, (char*)"Live Movement");
+            Draw_Menu_Item(row, ICON_Axis, "Live Movement");
             Draw_Checkbox(row, livemove);
           }
           else {
@@ -1312,7 +1312,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case MLEVEL_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             #if HAS_LEVELING
@@ -1323,7 +1323,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_BL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_AxisBL, (char*)"Bottom Left");
+            Draw_Menu_Item(row, ICON_AxisBL, "Bottom Left");
           }
           else {
             Popup_Handler(MoveWait);
@@ -1336,7 +1336,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_TL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_AxisTL, (char*)"Top Left");
+            Draw_Menu_Item(row, ICON_AxisTL, "Top Left");
           }
           else {
             Popup_Handler(MoveWait);
@@ -1349,7 +1349,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_TR:
           if (draw) {
-            Draw_Menu_Item(row, ICON_AxisTR, (char*)"Top Right");
+            Draw_Menu_Item(row, ICON_AxisTR, "Top Right");
           }
           else {
             Popup_Handler(MoveWait);
@@ -1362,7 +1362,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_BR:
           if (draw) {
-            Draw_Menu_Item(row, ICON_AxisBR, (char*)"Bottom Right");
+            Draw_Menu_Item(row, ICON_AxisBR, "Bottom Right");
           }
           else {
             Popup_Handler(MoveWait);
@@ -1375,7 +1375,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_C:
           if (draw) {
-            Draw_Menu_Item(row, ICON_AxisC, (char*)"Center");
+            Draw_Menu_Item(row, ICON_AxisC, "Center");
           }
           else {
             Popup_Handler(MoveWait);
@@ -1388,7 +1388,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MLEVEL_ZPOS:
           if (draw) {
-            Draw_Menu_Item(row, ICON_SetZOffset, (char*)"Z Position");
+            Draw_Menu_Item(row, ICON_SetZOffset, "Z Position");
             Draw_Float(mlev_z_pos, row, false, 100);
           }
           else {
@@ -1412,7 +1412,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case ZOFFSET_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               liveadjust = false;
@@ -1424,7 +1424,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ZOFFSET_HOME:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Homing, (char*)"Home Z Axis");
+              Draw_Menu_Item(row, ICON_Homing, "Home Z Axis");
             }
             else {
               Popup_Handler(Home);
@@ -1445,7 +1445,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ZOFFSET_MODE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Zoffset, (char*)"Live Adjustment");
+              Draw_Menu_Item(row, ICON_Zoffset, "Live Adjustment");
               Draw_Checkbox(row, liveadjust);
             }
             else {
@@ -1473,7 +1473,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ZOFFSET_OFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetZOffset, (char*)"Z Offset");
+              Draw_Menu_Item(row, ICON_SetZOffset, "Z Offset");
               Draw_Float(zoffsetvalue, row, false, 100);
             }
             else {
@@ -1482,7 +1482,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ZOFFSET_UP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Microstep Up");
+              Draw_Menu_Item(row, ICON_Axis, "Microstep Up");
             }
             else {
               if (zoffsetvalue < MAX_Z_OFFSET) {
@@ -1497,7 +1497,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ZOFFSET_DOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_AxisD, (char*)"Microstep Down");
+              Draw_Menu_Item(row, ICON_AxisD, "Microstep Down");
             }
             else {
               if (zoffsetvalue > MIN_Z_OFFSET) {
@@ -1513,7 +1513,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if ENABLED(EEPROM_SETTINGS)
             case ZOFFSET_SAVE:
               if (draw) {
-                Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Save");
+                Draw_Menu_Item(row, ICON_WriteEEPROM, "Save");
               }
               else {
                 AudioFeedback(settings.save());
@@ -1538,7 +1538,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Prepare, PREPARE_PREHEAT);
@@ -1546,7 +1546,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case PREHEAT_MODE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Homing, (char*)"Bed Only Mode");
+              Draw_Menu_Item(row, ICON_Homing, "Bed Only Mode");
               Draw_Checkbox(row, bedonly);
             }
             else {
@@ -1557,7 +1557,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 1)
             case PREHEAT_1:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_1_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_1_LABEL);
               }
               else {
                 if (!bedonly) {
@@ -1571,7 +1571,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 2)
             case PREHEAT_2:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_2_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_2_LABEL);
               }
               else {
                 if (!bedonly) {
@@ -1585,7 +1585,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 3)
             case PREHEAT_3:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_3_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_3_LABEL);
               }
               else {
                 if (!bedonly) {
@@ -1599,7 +1599,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 4)
             case PREHEAT_4:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_4_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_4_LABEL);
               }
               else {
                 if (!bedonly) {
@@ -1613,7 +1613,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 5)
             case PREHEAT_5:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_5_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_5_LABEL);
               }
               else {
                 if (!bedonly) {
@@ -1639,7 +1639,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case CHANGEFIL_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Prepare, PREPARE_CHANGEFIL);
@@ -1647,7 +1647,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case CHANGEFIL_LOAD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Load Filament");
+              Draw_Menu_Item(row, ICON_WriteEEPROM, "Load Filament");
             }
             else {
               if (thermalManager.temp_hotend[0].target < thermalManager.extrude_min_temp) {
@@ -1667,7 +1667,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case CHANGEFIL_UNLOAD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Unload Filament");
+              Draw_Menu_Item(row, ICON_ReadEEPROM, "Unload Filament");
             }
             else {
               if (thermalManager.temp_hotend[0].target < thermalManager.extrude_min_temp) {
@@ -1687,7 +1687,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case CHANGEFIL_CHANGE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
+              Draw_Menu_Item(row, ICON_ResumeEEPROM, "Change Filament");
             }
             else {
               if (thermalManager.temp_hotend[0].target < thermalManager.extrude_min_temp) {
@@ -1724,7 +1724,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case CONTROL_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Main_Menu(2);
@@ -1732,7 +1732,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case CONTROL_TEMP:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Temperature, (char*)"Temperature", NULL, true);
+            Draw_Menu_Item(row, ICON_Temperature, "Temperature", NULL, true);
           }
           else {
             Draw_Menu(TempMenu);
@@ -1740,7 +1740,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case CONTROL_MOTION:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Motion, (char*)"Motion", NULL, true);
+            Draw_Menu_Item(row, ICON_Motion, "Motion", NULL, true);
           }
           else {
             Draw_Menu(Motion);
@@ -1748,7 +1748,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case CONTROL_VISUAL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_PrintSize, (char*)"Visual", NULL, true);
+            Draw_Menu_Item(row, ICON_PrintSize, "Visual", NULL, true);
           }
           else {
             Draw_Menu(Visual);
@@ -1756,7 +1756,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case CONTROL_ADVANCED:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Version, (char*)"Advanced", NULL, true);
+            Draw_Menu_Item(row, ICON_Version, "Advanced", NULL, true);
           }
           else {
             Draw_Menu(Advanced);
@@ -1765,7 +1765,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(EEPROM_SETTINGS)
           case CONTROL_SAVE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Store Settings");
+              Draw_Menu_Item(row, ICON_WriteEEPROM, "Store Settings");
             }
             else {
               AudioFeedback(settings.save());
@@ -1773,7 +1773,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case CONTROL_RESTORE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Restore Settings");
+              Draw_Menu_Item(row, ICON_ReadEEPROM, "Restore Settings");
             }
             else {
               AudioFeedback(settings.load());
@@ -1781,7 +1781,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case CONTROL_RESET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Temperature, (char*)"Reset to Defaults");
+              Draw_Menu_Item(row, ICON_Temperature, "Reset to Defaults");
             }
             else {
               settings.reset();
@@ -1791,7 +1791,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #endif
         case CONTROL_INFO:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Info, (char*)"Info");
+            Draw_Menu_Item(row, ICON_Info, "Info");
           }
           else {
             Draw_Menu(Info);
@@ -1816,7 +1816,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case TEMP_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Control, CONTROL_TEMP);
@@ -1825,7 +1825,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case TEMP_HOTEND:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+              Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
               Draw_Float(thermalManager.temp_hotend[0].target, row, false, 1);
             }
             else {
@@ -1836,7 +1836,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HEATED_BED
           case TEMP_BED:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+              Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
               Draw_Float(thermalManager.temp_bed.target, row, false, 1);
             }
             else {
@@ -1847,7 +1847,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_FAN
           case TEMP_FAN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+              Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
               Draw_Float(thermalManager.fan_speed[0], row, false, 1);
             }
             else {
@@ -1858,7 +1858,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ANY(HAS_HOTEND, HAS_HEATED_BED)
           case TEMP_PID:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)"PID", NULL, true);
+              Draw_Menu_Item(row, ICON_Step, "PID", NULL, true);
             }
             else {
               Draw_Menu(PID);
@@ -1868,7 +1868,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if (PREHEAT_COUNT >= 1)
           case TEMP_PREHEAT1:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)PREHEAT_1_LABEL, NULL, true);
+              Draw_Menu_Item(row, ICON_Step, PREHEAT_1_LABEL, NULL, true);
             }
             else {
               Draw_Menu(Preheat1);
@@ -1878,7 +1878,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if (PREHEAT_COUNT >= 2)
           case TEMP_PREHEAT2:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)PREHEAT_2_LABEL, NULL, true);
+              Draw_Menu_Item(row, ICON_Step, PREHEAT_2_LABEL, NULL, true);
             }
             else {
               Draw_Menu(Preheat2);
@@ -1888,7 +1888,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if (PREHEAT_COUNT >= 3)
           case TEMP_PREHEAT3:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)PREHEAT_3_LABEL, NULL, true);
+              Draw_Menu_Item(row, ICON_Step, PREHEAT_3_LABEL, NULL, true);
             }
             else {
               Draw_Menu(Preheat3);
@@ -1898,7 +1898,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if (PREHEAT_COUNT >= 4)
           case TEMP_PREHEAT4:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)PREHEAT_4_LABEL, NULL, true);
+              Draw_Menu_Item(row, ICON_Step, PREHEAT_4_LABEL, NULL, true);
             }
             else {
               Draw_Menu(Preheat4);
@@ -1908,7 +1908,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if (PREHEAT_COUNT >= 5)
           case TEMP_PREHEAT5:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)PREHEAT_5_LABEL, NULL, true);
+              Draw_Menu_Item(row, ICON_Step, PREHEAT_5_LABEL, NULL, true);
             }
             else {
               Draw_Menu(Preheat5);
@@ -1931,7 +1931,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PID_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PID);
@@ -1940,7 +1940,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PID_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_HotendTemp, (char*)"Hotend", NULL, true);
+                Draw_Menu_Item(row, ICON_HotendTemp, "Hotend", NULL, true);
               }
               else {
                 Draw_Menu(HotendPID);
@@ -1950,7 +1950,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PID_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_BedTemp, (char*)"Bed", NULL, true);
+                Draw_Menu_Item(row, ICON_BedTemp, "Bed", NULL, true);
               }
               else {
                 Draw_Menu(BedPID);
@@ -1959,7 +1959,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #endif
           case PID_CYCLES:
             if (draw) {
-              Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Cycles");
+              Draw_Menu_Item(row, ICON_FanSpeed, "Cycles");
               Draw_Float(PID_cycles, row, false, 1);
             }
             else {
@@ -1985,7 +1985,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case HOTENDPID_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(PID, PID_HOTEND);
@@ -1993,7 +1993,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case HOTENDPID_TUNE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_HotendTemp, (char*)"Autotune");
+              Draw_Menu_Item(row, ICON_HotendTemp, "Autotune");
             }
             else {
               Popup_Handler(PIDWait);
@@ -2004,7 +2004,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case HOTENDPID_TEMP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Temperature, (char*)"Temperature");
+              Draw_Menu_Item(row, ICON_Temperature, "Temperature");
               Draw_Float(PID_e_temp, row, false, 1);
             }
             else {
@@ -2013,7 +2013,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case HOTENDPID_KP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Kp Value");
+              Draw_Menu_Item(row, ICON_Version, "Kp Value");
               Draw_Float(thermalManager.temp_hotend[0].pid.Kp, row, false, 100);
             }
             else {
@@ -2022,7 +2022,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case HOTENDPID_KI:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Ki Value");
+              Draw_Menu_Item(row, ICON_Version, "Ki Value");
               Draw_Float(unscalePID_i(thermalManager.temp_hotend[0].pid.Ki), row, false, 100);
             }
             else {
@@ -2031,7 +2031,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case HOTENDPID_KD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Kd Value");
+              Draw_Menu_Item(row, ICON_Version, "Kd Value");
               Draw_Float(unscalePID_d(thermalManager.temp_hotend[0].pid.Kd), row, false, 100);
             }
             else {
@@ -2057,7 +2057,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case BEDPID_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(PID, PID_BED);
@@ -2065,7 +2065,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case BEDPID_TUNE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_HotendTemp, (char*)"Autotune");
+              Draw_Menu_Item(row, ICON_HotendTemp, "Autotune");
             }
             else {
               Popup_Handler(PIDWait);
@@ -2076,7 +2076,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case BEDPID_TEMP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Temperature, (char*)"Temperature");
+              Draw_Menu_Item(row, ICON_Temperature, "Temperature");
               Draw_Float(PID_bed_temp, row, false, 1);
             }
             else {
@@ -2085,7 +2085,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case BEDPID_KP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Kp Value");
+              Draw_Menu_Item(row, ICON_Version, "Kp Value");
               Draw_Float(thermalManager.temp_bed.pid.Kp, row, false, 100);
             }
             else {
@@ -2094,7 +2094,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case BEDPID_KI:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Ki Value");
+              Draw_Menu_Item(row, ICON_Version, "Ki Value");
               Draw_Float(unscalePID_i(thermalManager.temp_bed.pid.Ki), row, false, 100);
             }
             else {
@@ -2103,7 +2103,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case BEDPID_KD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Version, (char*)"Kd Value");
+              Draw_Menu_Item(row, ICON_Version, "Kd Value");
               Draw_Float(unscalePID_d(thermalManager.temp_bed.pid.Kd), row, false, 100);
             }
             else {
@@ -2125,7 +2125,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT1_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PREHEAT1);
@@ -2134,7 +2134,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PREHEAT1_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+                Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
                 Draw_Float(ui.material_preset[0].hotend_temp, row, false, 1);
               }
               else {
@@ -2145,7 +2145,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PREHEAT1_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+                Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
                 Draw_Float(ui.material_preset[0].bed_temp, row, false, 1);
               }
               else {
@@ -2156,7 +2156,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_FAN
             case PREHEAT1_FAN:
               if (draw) {
-                Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+                Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
                 Draw_Float(ui.material_preset[0].fan_speed, row, false, 1);
               }
               else {
@@ -2179,7 +2179,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT2_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PREHEAT2);
@@ -2188,7 +2188,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PREHEAT2_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+                Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
                 Draw_Float(ui.material_preset[1].hotend_temp, row, false, 1);
               }
               else {
@@ -2199,7 +2199,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PREHEAT2_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+                Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
                 Draw_Float(ui.material_preset[1].bed_temp, row, false, 1);
               }
               else {
@@ -2210,7 +2210,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_FAN
             case PREHEAT2_FAN:
               if (draw) {
-                Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+                Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
                 Draw_Float(ui.material_preset[1].fan_speed, row, false, 1);
               }
               else {
@@ -2233,7 +2233,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT3_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PREHEAT3);
@@ -2242,7 +2242,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PREHEAT3_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+                Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
                 Draw_Float(ui.material_preset[2].hotend_temp, row, false, 1);
               }
               else {
@@ -2253,7 +2253,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PREHEAT3_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+                Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
                 Draw_Float(ui.material_preset[2].bed_temp, row, false, 1);
               }
               else {
@@ -2264,7 +2264,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_FAN
             case PREHEAT3_FAN:
               if (draw) {
-                Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+                Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
                 Draw_Float(ui.material_preset[2].fan_speed, row, false, 1);
               }
               else {
@@ -2287,7 +2287,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT4_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PREHEAT4);
@@ -2296,7 +2296,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PREHEAT4_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+                Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
                 Draw_Float(ui.material_preset[3].hotend_temp, row, false, 1);
               }
               else {
@@ -2307,7 +2307,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PREHEAT4_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+                Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
                 Draw_Float(ui.material_preset[3].bed_temp, row, false, 1);
               }
               else {
@@ -2318,7 +2318,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_FAN
             case PREHEAT4_FAN:
               if (draw) {
-                Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+                Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
                 Draw_Float(ui.material_preset[3].fan_speed, row, false, 1);
               }
               else {
@@ -2341,7 +2341,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEAT5_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(TempMenu, TEMP_PREHEAT5);
@@ -2350,7 +2350,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case PREHEAT5_HOTEND:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+                Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
                 Draw_Float(ui.material_preset[4].hotend_temp, row, false, 1);
               }
               else {
@@ -2361,7 +2361,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HEATED_BED
             case PREHEAT5_BED:
               if (draw) {
-                Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+                Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
                 Draw_Float(ui.material_preset[4].bed_temp, row, false, 1);
               }
               else {
@@ -2372,7 +2372,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_FAN
             case PREHEAT5_FAN:
               if (draw) {
-                Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+                Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
                 Draw_Float(ui.material_preset[4].fan_speed, row, false, 1);
               }
               else {
@@ -2397,7 +2397,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case MOTION_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Control, CONTROL_MOTION);
@@ -2405,7 +2405,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOTION_HOMEOFFSETS:
           if (draw) {
-            Draw_Menu_Item(row, ICON_SetHome, (char*)"Home Offsets", NULL, true);
+            Draw_Menu_Item(row, ICON_SetHome, "Home Offsets", NULL, true);
           }
           else {
             Draw_Menu(HomeOffsets);
@@ -2413,7 +2413,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOTION_SPEED:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Max Speed", NULL, true);
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Max Speed", NULL, true);
           }
           else {
             Draw_Menu(MaxSpeed);
@@ -2421,7 +2421,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case MOTION_ACCEL:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxAccelerated, (char*)"Max Acceleration", NULL, true);
+            Draw_Menu_Item(row, ICON_MaxAccelerated, "Max Acceleration", NULL, true);
           }
           else {
             Draw_Menu(MaxAcceleration);
@@ -2430,7 +2430,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_CLASSIC_JERK
           case MOTION_JERK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxJerk, (char*)"Max Jerk", NULL, true);
+              Draw_Menu_Item(row, ICON_MaxJerk, "Max Jerk", NULL, true);
             }
             else {
               Draw_Menu(MaxJerk);
@@ -2439,7 +2439,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #endif
         case MOTION_STEPS:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Step, (char*)"Steps/mm", NULL, true);
+            Draw_Menu_Item(row, ICON_Step, "Steps/mm", NULL, true);
           }
           else {
             Draw_Menu(Steps);
@@ -2448,7 +2448,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case MOTION_FLOW:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Speed, (char*)"Flow Rate");
+              Draw_Menu_Item(row, ICON_Speed, "Flow Rate");
               Draw_Float(planner.flow_percentage[0], row, false, 1);
             }
             else {
@@ -2468,7 +2468,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case HOMEOFFSETS_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Motion, MOTION_HOMEOFFSETS);
@@ -2476,7 +2476,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOMEOFFSETS_XOFFSET:
           if (draw) {
-            Draw_Menu_Item(row, ICON_StepX, (char*)"X Offset");
+            Draw_Menu_Item(row, ICON_StepX, "X Offset");
             Draw_Float(home_offset.x, row, false, 100);
           }
           else {
@@ -2485,7 +2485,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case HOMEOFFSETS_YOFFSET:
           if (draw) {
-            Draw_Menu_Item(row, ICON_StepY, (char*)"Y Offset");
+            Draw_Menu_Item(row, ICON_StepY, "Y Offset");
             Draw_Float(home_offset.y, row, false, 100);
           }
           else {
@@ -2506,7 +2506,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case SPEED_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Motion, MOTION_SPEED);
@@ -2514,7 +2514,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case SPEED_X:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeedX, (char*)"X Axis");
+            Draw_Menu_Item(row, ICON_MaxSpeedX, "X Axis");
             Draw_Float(planner.settings.max_feedrate_mm_s[X_AXIS], row, false, 1);
           }
           else {
@@ -2523,7 +2523,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case SPEED_Y:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeedY, (char*)"Y Axis");
+            Draw_Menu_Item(row, ICON_MaxSpeedY, "Y Axis");
             Draw_Float(planner.settings.max_feedrate_mm_s[Y_AXIS], row, false, 1);
           }
           else {
@@ -2532,7 +2532,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case SPEED_Z:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeedZ, (char*)"Z Axis");
+            Draw_Menu_Item(row, ICON_MaxSpeedZ, "Z Axis");
             Draw_Float(planner.settings.max_feedrate_mm_s[Z_AXIS], row, false, 1);
           }
           else {
@@ -2542,7 +2542,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case SPEED_E:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedE, (char*)"Extruder");
+              Draw_Menu_Item(row, ICON_MaxSpeedE, "Extruder");
               Draw_Float(planner.settings.max_feedrate_mm_s[E_AXIS], row, false, 1);
             }
             else {
@@ -2564,7 +2564,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case ACCEL_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Motion, MOTION_ACCEL);
@@ -2572,7 +2572,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case ACCEL_X:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxAccX, (char*)"X Axis");
+            Draw_Menu_Item(row, ICON_MaxAccX, "X Axis");
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[X_AXIS], row, false, 1);
           }
           else {
@@ -2581,7 +2581,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case ACCEL_Y:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxAccY, (char*)"Y Axis");
+            Draw_Menu_Item(row, ICON_MaxAccY, "Y Axis");
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[Y_AXIS], row, false, 1);
           }
           else {
@@ -2590,7 +2590,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case ACCEL_Z:
           if (draw) {
-            Draw_Menu_Item(row, ICON_MaxAccZ, (char*)"Z Axis");
+            Draw_Menu_Item(row, ICON_MaxAccZ, "Z Axis");
             Draw_Float(planner.settings.max_acceleration_mm_per_s2[Z_AXIS], row, false, 1);
           }
           else {
@@ -2600,7 +2600,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case ACCEL_E:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxAccE, (char*)"Extruder");
+              Draw_Menu_Item(row, ICON_MaxAccE, "Extruder");
               Draw_Float(planner.settings.max_acceleration_mm_per_s2[E_AXIS], row, false, 1);
             }
             else {
@@ -2623,7 +2623,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case JERK_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Motion, MOTION_JERK);
@@ -2631,7 +2631,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case JERK_X:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkX, (char*)"X Axis");
+              Draw_Menu_Item(row, ICON_MaxSpeedJerkX, "X Axis");
               Draw_Float(planner.max_jerk[X_AXIS], row, false, 10);
             }
             else {
@@ -2640,7 +2640,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case JERK_Y:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkY, (char*)"Y Axis");
+              Draw_Menu_Item(row, ICON_MaxSpeedJerkY, "Y Axis");
               Draw_Float(planner.max_jerk[Y_AXIS], row, false, 10);
             }
             else {
@@ -2649,7 +2649,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case JERK_Z:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, (char*)"Z Axis");
+              Draw_Menu_Item(row, ICON_MaxSpeedJerkZ, "Z Axis");
               Draw_Float(planner.max_jerk[Z_AXIS], row, false, 10);
             }
             else {
@@ -2659,7 +2659,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if HAS_HOTEND
             case JERK_E:
               if (draw) {
-                Draw_Menu_Item(row, ICON_MaxSpeedJerkE, (char*)"Extruder");
+                Draw_Menu_Item(row, ICON_MaxSpeedJerkE, "Extruder");
                 Draw_Float(planner.max_jerk[E_AXIS], row, false, 10);
               }
               else {
@@ -2682,7 +2682,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case STEPS_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Motion, MOTION_STEPS);
@@ -2690,7 +2690,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case STEPS_X:
           if (draw) {
-            Draw_Menu_Item(row, ICON_StepX, (char*)"X Axis");
+            Draw_Menu_Item(row, ICON_StepX, "X Axis");
             Draw_Float(planner.settings.axis_steps_per_mm[X_AXIS], row, false, 10);
           }
           else {
@@ -2699,7 +2699,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case STEPS_Y:
           if (draw) {
-            Draw_Menu_Item(row, ICON_StepY, (char*)"Y Axis");
+            Draw_Menu_Item(row, ICON_StepY, "Y Axis");
             Draw_Float(planner.settings.axis_steps_per_mm[Y_AXIS], row, false, 10);
           }
           else {
@@ -2708,7 +2708,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case STEPS_Z:
           if (draw) {
-            Draw_Menu_Item(row, ICON_StepZ, (char*)"Z Axis");
+            Draw_Menu_Item(row, ICON_StepZ, "Z Axis");
             Draw_Float(planner.settings.axis_steps_per_mm[Z_AXIS], row, false, 10);
           }
           else {
@@ -2718,7 +2718,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case STEPS_E:
             if (draw) {
-              Draw_Menu_Item(row, ICON_StepE, (char*)"Extruder");
+              Draw_Menu_Item(row, ICON_StepE, "Extruder");
               Draw_Float(planner.settings.axis_steps_per_mm[E_AXIS], row, false, 10);
             }
             else {
@@ -2741,7 +2741,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case VISUAL_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Control, CONTROL_VISUAL);
@@ -2749,7 +2749,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case VISUAL_BACKLIGHT:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Brightness, (char*)"Display Off");
+            Draw_Menu_Item(row, ICON_Brightness, "Display Off");
           }
           else {
             ui.set_brightness(0);
@@ -2757,7 +2757,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case VISUAL_BRIGHTNESS:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Brightness, (char*)"LCD Brightness");
+            Draw_Menu_Item(row, ICON_Brightness, "LCD Brightness");
             Draw_Float(ui.brightness, row, false, 1);
           }
           else {
@@ -2766,7 +2766,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case VISUAL_TIME_FORMAT:
           if (draw) {
-            Draw_Menu_Item(row, ICON_PrintTime, (char*)"Progress as __h__m");
+            Draw_Menu_Item(row, ICON_PrintTime, "Progress as __h__m");
             Draw_Checkbox(row, eeprom_settings.time_format_textual);
           }
           else {
@@ -2776,7 +2776,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case VISUAL_COLOR_THEMES:
         if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"UI Color Settings", NULL, true);
+            Draw_Menu_Item(row, ICON_MaxSpeed, "UI Color Settings", NULL, true);
           }
           else {
             Draw_Menu(ColorSettings);
@@ -2803,7 +2803,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
         case COLORSETTINGS_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Visual, VISUAL_COLOR_THEMES);
@@ -2811,7 +2811,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case COLORSETTINGS_CURSOR:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Cursor");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Cursor");
             Draw_Option(eeprom_settings.cursor_color, color_names, row, false, true);
           }
           else {
@@ -2820,7 +2820,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
           case COLORSETTINGS_SPLIT_LINE:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Menu Split Line");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Menu Split Line");
             Draw_Option(eeprom_settings.menu_split_line, color_names, row, false, true);
           }
           else {
@@ -2829,7 +2829,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case COLORSETTINGS_MENU_TOP_TXT:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Menu Header Text");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Menu Header Text");
             Draw_Option(eeprom_settings.menu_top_txt, color_names, row, false, true);
           }
           else {
@@ -2838,7 +2838,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
          case COLORSETTINGS_MENU_TOP_BG:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Menu Header Bg");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Menu Header Bg");
             Draw_Option(eeprom_settings.menu_top_bg, color_names, row, false, true);
           }
           else {
@@ -2847,7 +2847,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;  
           case COLORSETTINGS_HIGHLIGHT_BORDER:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Highlight Box");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Highlight Box");
             Draw_Option(eeprom_settings.highlight_box, color_names, row, false, true);
           }
           else {
@@ -2856,7 +2856,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break; 
           case COLORSETTINGS_PROGRESS_PERCENT:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Progress Percent");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Progress Percent");
             Draw_Option(eeprom_settings.progress_percent, color_names, row, false, true);
           }
           else {
@@ -2865,7 +2865,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;  
           case COLORSETTINGS_PROGRESS_TIME:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Progress Time");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Progress Time");
             Draw_Option(eeprom_settings.progress_time, color_names, row, false, true);
           }
           else {
@@ -2874,7 +2874,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;           
           case COLORSETTINGS_PROGRESS_STATUS_BAR:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Status Bar Text");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Status Bar Text");
             Draw_Option(eeprom_settings.status_bar_text, color_names, row, false, true);
           }
           else {
@@ -2883,7 +2883,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;  
           case COLORSETTINGS_PROGRESS_STATUS_AREA:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Status Area Text");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Status Area Text");
             Draw_Option(eeprom_settings.status_area_text, color_names, row, false, true);
           }
           else {
@@ -2892,7 +2892,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;  
           case COLORSETTINGS_PROGRESS_COORDINATES:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Coordinates Text");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Coordinates Text");
             Draw_Option(eeprom_settings.coordinates_text, color_names, row, false, true);
           }
           else {
@@ -2901,7 +2901,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;     
           case COLORSETTINGS_PROGRESS_COORDINATES_LINE:
            if (draw) {
-            Draw_Menu_Item(row, ICON_MaxSpeed, (char*)"Coordinates Line");
+            Draw_Menu_Item(row, ICON_MaxSpeed, "Coordinates Line");
             Draw_Option(eeprom_settings.coordinates_split_line, color_names, row, false, true);
           }
           else {
@@ -2927,7 +2927,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case ADVANCED_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Menu(Control, CONTROL_ADVANCED);
@@ -2935,7 +2935,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case ADVANCED_BEEPER:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Version, (char*)"LCD Beeper");
+            Draw_Menu_Item(row, ICON_Version, "LCD Beeper");
             Draw_Checkbox(row, eeprom_settings.beeperenable);
           }
           else {
@@ -2946,7 +2946,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_BED_PROBE
           case ADVANCED_PROBE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_StepX, (char*)"Probe", NULL, true);
+              Draw_Menu_Item(row, ICON_StepX, "Probe", NULL, true);
             }
             else {
               Draw_Menu(ProbeMenu);
@@ -2956,7 +2956,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(LIN_ADVANCE)
           case ADVANCED_LA:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MaxAccelerated, (char*)"Lin Advance Kp");
+              Draw_Menu_Item(row, ICON_MaxAccelerated, "Lin Advance Kp");
               Draw_Float(planner.extruder_advance_K[0], row, false, 100);
             }
             else {
@@ -2967,7 +2967,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(ADVANCED_PAUSE_FEATURE)
           case ADVANCED_LOAD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Load Length");
+              Draw_Menu_Item(row, ICON_WriteEEPROM, "Load Length");
               Draw_Float(fc_settings[0].load_length, row, false, 1);
             }
             else {
@@ -2976,7 +2976,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case ADVANCED_UNLOAD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Unload Length");
+              Draw_Menu_Item(row, ICON_ReadEEPROM, "Unload Length");
               Draw_Float(fc_settings[0].unload_length, row, false, 1);
             }
             else {
@@ -2987,7 +2987,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(PREVENT_COLD_EXTRUSION)
           case ADVANCED_COLD_EXTRUDE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Cool, (char*)"Min Extrusion T");
+              Draw_Menu_Item(row, ICON_Cool, "Min Extrusion T");
               Draw_Float(thermalManager.extrude_min_temp, row, false, 1);
             }
             else {
@@ -2999,7 +2999,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(FILAMENT_RUNOUT_SENSOR)
           case ADVANCED_FILSENSORENABLED:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Extruder, (char*)"Filament Sensor");
+              Draw_Menu_Item(row, ICON_Extruder, "Filament Sensor");
               Draw_Checkbox(row, runout.enabled);
             }
             else {
@@ -3010,7 +3010,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if ENABLED(HAS_FILAMENT_RUNOUT_DISTANCE)
             case ADVANCED_FILSENSORDISTANCE:
               if (draw) {
-                Draw_Menu_Item(row, ICON_MaxAccE, (char*)"Runout Distance");
+                Draw_Menu_Item(row, ICON_MaxAccE, "Runout Distance");
                 Draw_Float(runout.runout_distance(), row, false, 10);
               }
               else {
@@ -3022,7 +3022,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(POWER_LOSS_RECOVERY)
           case ADVANCED_POWER_LOSS:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Motion, (char*)"Power-loss recovery");
+              Draw_Menu_Item(row, ICON_Motion, "Power-loss recovery");
               Draw_Checkbox(row, recovery.enabled);
             }
             else {
@@ -3048,7 +3048,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PROBE_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Advanced, ADVANCED_PROBE);
@@ -3057,7 +3057,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           
             case PROBE_XOFFSET:
               if (draw) {
-                Draw_Menu_Item(row, ICON_StepX, (char*)"Probe X Offset");
+                Draw_Menu_Item(row, ICON_StepX, "Probe X Offset");
                 Draw_Float(probe.offset.x, row, false, 10);
               }
               else {
@@ -3066,7 +3066,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               break;
             case PROBE_YOFFSET:
               if (draw) {
-                Draw_Menu_Item(row, ICON_StepY, (char*)"Probe Y Offset");
+                Draw_Menu_Item(row, ICON_StepY, "Probe Y Offset");
                 Draw_Float(probe.offset.y, row, false, 10);
               }
               else {
@@ -3075,7 +3075,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               break;
             case PROBE_TEST:
               if (draw) {
-                Draw_Menu_Item(row, ICON_StepY, (char*)"M48 Probe Test");
+                Draw_Menu_Item(row, ICON_StepY, "M48 Probe Test");
               }
               else {
                 char buf[50];
@@ -3085,7 +3085,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               break;
             case PROBE_TEST_COUNT:
               if (draw) {
-                Draw_Menu_Item(row, ICON_StepY, (char*)"Probe Test Count");
+                Draw_Menu_Item(row, ICON_StepY, "Probe Test Count");
                 Draw_Float(testcount, row, false, 1);
               }
               else {
@@ -3110,7 +3110,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case INFO_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
             
             #if ENABLED(PRINTCOUNTER)
               char row1[32], row2[32], buf[32];
@@ -3127,9 +3127,9 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               Draw_Menu_Item(INFO_PRINTTIME, ICON_PrintTime, row1, row2, false, true);
             #endif
             
-            Draw_Menu_Item(INFO_SIZE, ICON_PrintSize, (char*)MACHINE_SIZE, NULL, false, true);
-            Draw_Menu_Item(INFO_VERSION, ICON_Version, (char*)SHORT_BUILD_VERSION, (char*)"Build Number: v" BUILD_NUMBER, false, true);
-            Draw_Menu_Item(INFO_CONTACT, ICON_Contact, (char*)CORP_WEBSITE_E, NULL, false, true);
+            Draw_Menu_Item(INFO_SIZE, ICON_PrintSize, MACHINE_SIZE, NULL, false, true);
+            Draw_Menu_Item(INFO_VERSION, ICON_Version, SHORT_BUILD_VERSION, "Build Number: v" BUILD_NUMBER, false, true);
+            Draw_Menu_Item(INFO_CONTACT, ICON_Contact, CORP_WEBSITE_E, NULL, false, true);
           }
           else {
             if (menu == Info)
@@ -3157,7 +3157,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case LEVELING_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Main_Menu(3);
@@ -3165,14 +3165,14 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_ACTIVE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_StockConfiguraton, (char*)"Leveling Active");
+              Draw_Menu_Item(row, ICON_StockConfiguraton, "Leveling Active");
               Draw_Checkbox(row, planner.leveling_active);
             }
             else {
               if (!planner.leveling_active) {
                 set_bed_leveling_enabled(!planner.leveling_active);
                 if (!planner.leveling_active) {
-                  Confirm_Handler((char*)"Couldn't enable Leveling");
+                  Confirm_Handler("Couldn't enable Leveling");
                   break;
                 }
               }
@@ -3185,7 +3185,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if BOTH(HAS_BED_PROBE, AUTO_BED_LEVELING_UBL)
             case LEVELING_GET_TILT:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Tilt, (char*)"Autotilt Current Mesh");
+                Draw_Menu_Item(row, ICON_Tilt, "Autotilt Current Mesh");
               }
               else {
                 Popup_Handler(Home);
@@ -3206,7 +3206,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #endif
           case LEVELING_GET_MESH:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Mesh, (char*)"Create New Mesh");
+              Draw_Menu_Item(row, ICON_Mesh, "Create New Mesh");
             }
             else {
               Popup_Handler(Home);
@@ -3226,7 +3226,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                   gcode.process_subcommands_now_P(PSTR("G29 P0\nG29 P1"));
                   gcode.process_subcommands_now_P(PSTR("G29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nG29 P3\nM420 S1"));
                   planner.synchronize();
-                  Update_Status((char*)"Probed all reachable points");
+                  Update_Status("Probed all reachable points");
                   Popup_Handler(SaveLevel);
                 #else
                   level_state = planner.leveling_active;
@@ -3255,12 +3255,12 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_MANUAL:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Mesh, (char*)"Manual Tuning", NULL, true);
+              Draw_Menu_Item(row, ICON_Mesh, "Manual Tuning", NULL, true);
             }
             else {
               #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
                 if (!leveling_is_valid()) {
-                  Confirm_Handler((char*)"Invalid Mesh");
+                  Confirm_Handler("Invalid Mesh");
                   break;
                 }
               #endif
@@ -3287,7 +3287,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Mesh, (char*)"Mesh Viewer", NULL, true);
+              Draw_Menu_Item(row, ICON_Mesh, "Mesh Viewer", NULL, true);
             }
             else {
               Draw_Menu(LevelView);
@@ -3295,7 +3295,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_SETTINGS:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Step, (char*)"Leveling Settings", NULL, true);
+              Draw_Menu_Item(row, ICON_Step, "Leveling Settings", NULL, true);
             }
             else {
               Draw_Menu(LevelSettings);
@@ -3304,7 +3304,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if ENABLED(AUTO_BED_LEVELING_UBL)
           case LEVELING_LOAD:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ReadEEPROM, (char*)"Load Mesh");
+              Draw_Menu_Item(row, ICON_ReadEEPROM, "Load Mesh");
             }
             else {
               gcode.process_subcommands_now_P(PSTR("G29 L"));
@@ -3314,7 +3314,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_SAVE:
             if(draw) {
-              Draw_Menu_Item(row, ICON_WriteEEPROM, (char*)"Save Mesh");
+              Draw_Menu_Item(row, ICON_WriteEEPROM, "Save Mesh");
             }
             else {
               gcode.process_subcommands_now_P(PSTR("G29 S"));
@@ -3336,7 +3336,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case LEVELING_VIEW_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Leveling, LEVELING_VIEW);
@@ -3344,7 +3344,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_MESH:
             if (draw) {
-              Draw_Menu_Item(row, ICON_PrintSize, (char*)"Mesh Viewer", NULL, true);
+              Draw_Menu_Item(row, ICON_PrintSize, "Mesh Viewer", NULL, true);
             }
             else {
               Draw_Menu(MeshViewer);
@@ -3352,7 +3352,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_TEXT:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Contact, (char*)"Viewer Show Values");
+              Draw_Menu_Item(row, ICON_Contact, "Viewer Show Values");
               Draw_Checkbox(row, mesh_conf.viewer_print_value);
             }
             else {
@@ -3362,7 +3362,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_ASYMMETRIC:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Viewer Asymmetric");
+              Draw_Menu_Item(row, ICON_Axis, "Viewer Asymmetric");
               Draw_Checkbox(row, mesh_conf.viewer_asymmetric_range);
             }
             else {
@@ -3386,7 +3386,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case LEVELING_SETTINGS_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               Draw_Menu(Leveling, LEVELING_SETTINGS);
@@ -3394,7 +3394,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_SETTINGS_FADE:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Fade, (char*)"Fade Mesh within");
+                Draw_Menu_Item(row, ICON_Fade, "Fade Mesh within");
                 Draw_Float(planner.z_fade_height, row, false, 1);
               }
               else {
@@ -3406,7 +3406,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if ENABLED(AUTO_BED_LEVELING_UBL)
             case LEVELING_SETTINGS_SLOT:
                 if (draw) {
-                  Draw_Menu_Item(row, ICON_PrintSize, (char*)"Mesh Slot");
+                  Draw_Menu_Item(row, ICON_PrintSize, "Mesh Slot");
                   Draw_Float(ubl.storage_slot, row, false, 1);
                 }
                 else {
@@ -3415,7 +3415,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                 break;
             case LEVELING_SETTINGS_TILT:
                 if (draw) {
-                  Draw_Menu_Item(row, ICON_Tilt, (char*)"Tilting Grid Size");
+                  Draw_Menu_Item(row, ICON_Tilt, "Tilting Grid Size");
                   Draw_Float(mesh_conf.tilt_grid, row, false, 1);
                 }
                 else {
@@ -3424,11 +3424,11 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                 break;
             case LEVELING_SETTINGS_PLANE:
                 if (draw) {
-                  Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Convert Mesh to Plane");
+                  Draw_Menu_Item(row, ICON_ResumeEEPROM, "Convert Mesh to Plane");
                 }
                 else {
                   if (mesh_conf.create_plane_from_mesh()) {
-                    Confirm_Handler((char*)"Error: Couldn't create plane!");
+                    Confirm_Handler("Error: Couldn't create plane!");
                     break;
                   }
                   gcode.process_subcommands_now_P(PSTR("M420 S1"));
@@ -3438,7 +3438,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                 break;
             case LEVELING_SETTINGS_ZERO:
                 if (draw) {
-                  Draw_Menu_Item(row, ICON_Mesh, (char*)"Zero Current Mesh");
+                  Draw_Menu_Item(row, ICON_Mesh, "Zero Current Mesh");
                 }
                 else {
                   gcode.process_subcommands_now_P(PSTR("G29 P0"));
@@ -3447,7 +3447,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                 break;
               case LEVELING_SETTINGS_UNDEF:
                 if (draw) {
-                  Draw_Menu_Item(row, ICON_Mesh, (char*)"Clear Current Mesh");
+                  Draw_Menu_Item(row, ICON_Mesh, "Clear Current Mesh");
                 }
                 else {
                   ubl.invalidate();
@@ -3463,7 +3463,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case MESHVIEW_BACK:
             if (draw) {
-              Draw_Menu_Item(0, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(0, ICON_Back, "Back");
               mesh_conf.Draw_Bed_Mesh();
               mesh_conf.Set_Mesh_Viewer_Status();
             }
@@ -3492,7 +3492,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case LEVELING_M_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               set_bed_leveling_enabled(level_state);
@@ -3504,7 +3504,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_X:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MoveX, (char*)"Mesh Point X");
+              Draw_Menu_Item(row, ICON_MoveX, "Mesh Point X");
               Draw_Float(mesh_conf.mesh_x, row, 0, 1);
             }
             else {
@@ -3513,7 +3513,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_Y:
             if (draw) {
-              Draw_Menu_Item(row, ICON_MoveY, (char*)"Mesh Point Y");
+              Draw_Menu_Item(row, ICON_MoveY, "Mesh Point Y");
               Draw_Float(mesh_conf.mesh_y, row, 0, 1);
             }
             else {
@@ -3522,7 +3522,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_NEXT:
             if (draw) {
-              Draw_Menu_Item(row, ICON_More, (char*)"Next Point");
+              Draw_Menu_Item(row, ICON_More, "Next Point");
             }
             else {
               if (mesh_conf.mesh_x != (GRID_MAX_POINTS_X-1) || mesh_conf.mesh_y != (GRID_MAX_POINTS_Y-1)) {
@@ -3541,7 +3541,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_OFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetZOffset, (char*)"Point Z Offset");
+              Draw_Menu_Item(row, ICON_SetZOffset, "Point Z Offset");
               Draw_Float(mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y], row, false, 100);
             }
             else {
@@ -3552,7 +3552,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_UP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Microstep Up");
+              Draw_Menu_Item(row, ICON_Axis, "Microstep Up");
             }
             else {
               if (mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y] < MAX_Z_OFFSET) {
@@ -3567,7 +3567,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_DOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_AxisD, (char*)"Microstep Down");
+              Draw_Menu_Item(row, ICON_AxisD, "Microstep Down");
             }
             else {
               if (mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y] > MIN_Z_OFFSET) {
@@ -3582,7 +3582,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_M_GOTO_VALUE: 
             if (draw) {
-              Draw_Menu_Item(row, ICON_StockConfiguraton, (char*)"Go to Mesh Z Value");
+              Draw_Menu_Item(row, ICON_StockConfiguraton, "Go to Mesh Z Value");
               Draw_Checkbox(row, mesh_conf.goto_mesh_value);
             }
             else {
@@ -3595,7 +3595,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if ENABLED(AUTO_BED_LEVELING_UBL)
           case LEVELING_M_UNDEF:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Clear Point Value");
+              Draw_Menu_Item(row, ICON_ResumeEEPROM, "Clear Point Value");
             }
             else {
               mesh_conf.manual_value_update(true);
@@ -3620,7 +3620,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case UBL_M_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+              Draw_Menu_Item(row, ICON_Back, "Back");
             }
             else {
               set_bed_leveling_enabled(level_state);
@@ -3630,9 +3630,9 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           case UBL_M_NEXT:
             if (draw) {
               if (mesh_conf.mesh_x != (GRID_MAX_POINTS_X-1) || mesh_conf.mesh_y != (GRID_MAX_POINTS_Y-1))
-                Draw_Menu_Item(row, ICON_More, (char*)"Next Point");
+                Draw_Menu_Item(row, ICON_More, "Next Point");
               else
-                Draw_Menu_Item(row, ICON_More, (char*)"Save Mesh");
+                Draw_Menu_Item(row, ICON_More, "Save Mesh");
             }
             else {
               if (mesh_conf.mesh_x != (GRID_MAX_POINTS_X-1) || mesh_conf.mesh_y != (GRID_MAX_POINTS_Y-1)) {
@@ -3657,7 +3657,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case UBL_M_PREV:
             if (draw) {
-              Draw_Menu_Item(row, ICON_More, (char*)"Previous Point");
+              Draw_Menu_Item(row, ICON_More, "Previous Point");
             }
             else {
               if (mesh_conf.mesh_x != 0 || mesh_conf.mesh_y != 0) {
@@ -3676,7 +3676,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case UBL_M_OFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetZOffset, (char*)"Point Z Offset");
+              Draw_Menu_Item(row, ICON_SetZOffset, "Point Z Offset");
               Draw_Float(mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y], row, false, 100);
             }
             else {
@@ -3687,7 +3687,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case UBL_M_UP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Microstep Up");
+              Draw_Menu_Item(row, ICON_Axis, "Microstep Up");
             }
             else {
               if (mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y] < MAX_Z_OFFSET) {
@@ -3702,7 +3702,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case UBL_M_DOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Microstep Down");
+              Draw_Menu_Item(row, ICON_Axis, "Microstep Down");
             }
             else {
               if (mesh_conf.mesh_z_values[mesh_conf.mesh_x][mesh_conf.mesh_y] > MIN_Z_OFFSET) {
@@ -3732,7 +3732,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case MMESH_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Cancel");
+              Draw_Menu_Item(row, ICON_Back, "Cancel");
             }
             else {
               gcode.process_subcommands_now_P(PSTR("G29 A"));
@@ -3744,9 +3744,9 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           case MMESH_NEXT:
             if (draw) {
               if (gridpoint < GRID_MAX_POINTS)
-                Draw_Menu_Item(row, ICON_More, (char*)"Next Point");
+                Draw_Menu_Item(row, ICON_More, "Next Point");
               else
-                Draw_Menu_Item(row, ICON_More, (char*)"Save Mesh");
+                Draw_Menu_Item(row, ICON_More, "Save Mesh");
             }
             else {
               if (gridpoint < GRID_MAX_POINTS) {
@@ -3766,7 +3766,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case MMESH_OFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetZOffset, (char*)"Z Position");
+              Draw_Menu_Item(row, ICON_SetZOffset, "Z Position");
               current_position.z = MANUAL_PROBE_START_Z;
               Draw_Float(current_position.z, row, false, 100);
             }
@@ -3776,7 +3776,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case MMESH_UP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Microstep Up");
+              Draw_Menu_Item(row, ICON_Axis, "Microstep Up");
             }
             else {
               if (current_position.z < MAX_Z_OFFSET) {
@@ -3790,7 +3790,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case MMESH_DOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_AxisD, (char*)"Microstep Down");
+              Draw_Menu_Item(row, ICON_AxisD, "Microstep Down");
             }
             else {
               if (current_position.z > MIN_Z_OFFSET) {
@@ -3815,7 +3815,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             const float currval = mesh_z_values[mesh_x][mesh_y];
 
             if (draw) {
-              Draw_Menu_Item(row, ICON_Zoffset, (char*)"Goto Mesh Value");
+              Draw_Menu_Item(row, ICON_Zoffset, "Goto Mesh Value");
               Draw_Float(currval, row, false, 100);
             } else {
               if (!isnan(currval)) {
@@ -3850,7 +3850,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       switch (item) {
         case TUNE_BACK:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Back, (char*)"Back");
+            Draw_Menu_Item(row, ICON_Back, "Back");
           }
           else {
             Draw_Print_Screen();
@@ -3858,7 +3858,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case TUNE_SPEED:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Speed, (char*)"Print Speed");
+            Draw_Menu_Item(row, ICON_Speed, "Print Speed");
             Draw_Float(feedrate_percentage, row, false, 1);
           }
           else {
@@ -3868,7 +3868,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HOTEND
           case TUNE_FLOW:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Speed, (char*)"Flow Rate");
+              Draw_Menu_Item(row, ICON_Speed, "Flow Rate");
               Draw_Float(planner.flow_percentage[0], row, false, 1);
             }
             else {
@@ -3877,7 +3877,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case TUNE_HOTEND:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Hotend");
+              Draw_Menu_Item(row, ICON_SetEndTemp, "Hotend");
               Draw_Float(thermalManager.temp_hotend[0].target, row, false, 1);
             }
             else {
@@ -3888,7 +3888,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_HEATED_BED
           case TUNE_BED:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetBedTemp, (char*)"Bed");
+              Draw_Menu_Item(row, ICON_SetBedTemp, "Bed");
               Draw_Float(thermalManager.temp_bed.target, row, false, 1);
             }
             else {
@@ -3899,7 +3899,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_FAN
           case TUNE_FAN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Fan");
+              Draw_Menu_Item(row, ICON_FanSpeed, "Fan");
               Draw_Float(thermalManager.fan_speed[0], row, false, 1);
             }
             else {
@@ -3910,7 +3910,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if HAS_ZOFFSET_ITEM
           case TUNE_ZOFFSET:
             if (draw) {
-              Draw_Menu_Item(row, ICON_FanSpeed, (char*)"Z-Offset");
+              Draw_Menu_Item(row, ICON_FanSpeed, "Z-Offset");
               Draw_Float(zoffsetvalue, row, false, 100);
             }
             else {
@@ -3919,7 +3919,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case TUNE_ZUP:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Axis, (char*)"Z-Offset Up");
+              Draw_Menu_Item(row, ICON_Axis, "Z-Offset Up");
             }
             else {
               if (zoffsetvalue < MAX_Z_OFFSET) {
@@ -3931,7 +3931,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case TUNE_ZDOWN:
             if (draw) {
-              Draw_Menu_Item(row, ICON_AxisD, (char*)"Z-Offset Down");
+              Draw_Menu_Item(row, ICON_AxisD, "Z-Offset Down");
             }
             else {
               if (zoffsetvalue > MIN_Z_OFFSET) {
@@ -3945,7 +3945,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
           case TUNE_CHANGEFIL:
             if (draw) {
-              Draw_Menu_Item(row, ICON_ResumeEEPROM, (char*)"Change Filament");
+              Draw_Menu_Item(row, ICON_ResumeEEPROM, "Change Filament");
             }
             else {
               Popup_Handler(ConfFilChange);
@@ -3955,7 +3955,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #if ENABLED(FILAMENT_RUNOUT_SENSOR)
           case TUNE_FILSENSORENABLED:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Extruder, (char*)"Filament Sensor");
+              Draw_Menu_Item(row, ICON_Extruder, "Filament Sensor");
               Draw_Checkbox(row, runout.enabled);
             }
             else {
@@ -3966,7 +3966,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         #endif
         case TUNE_BACKLIGHT_OFF:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Brightness, (char*)"Display Off");
+            Draw_Menu_Item(row, ICON_Brightness, "Display Off");
           }
           else {
             ui.set_brightness(0);
@@ -3974,7 +3974,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           break;
         case TUNE_BACKLIGHT:
           if (draw) {
-            Draw_Menu_Item(row, ICON_Brightness, (char*)"LCD Brightness");
+            Draw_Menu_Item(row, ICON_Brightness, "LCD Brightness");
             Draw_Float(ui.brightness, row, false, 1);
           }
           else {
@@ -3998,7 +3998,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         switch (item) {
           case PREHEATHOTEND_BACK:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Back, (char*)"Cancel");
+              Draw_Menu_Item(row, ICON_Back, "Cancel");
             }
             else {
               thermalManager.setTargetHotend(0, 0);
@@ -4009,7 +4009,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 1)
             case PREHEATHOTEND_1:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_1_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_1_LABEL);
               }
               else {
                 thermalManager.setTargetHotend(ui.material_preset[0].hotend_temp, 0);
@@ -4020,7 +4020,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 2)
             case PREHEATHOTEND_2:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_2_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_2_LABEL);
               }
               else {
                 thermalManager.setTargetHotend(ui.material_preset[1].hotend_temp, 0);
@@ -4031,7 +4031,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 3)
             case PREHEATHOTEND_3:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_3_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_3_LABEL);
               }
               else {
                 thermalManager.setTargetHotend(ui.material_preset[2].hotend_temp, 0);
@@ -4042,7 +4042,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 4)
             case PREHEATHOTEND_4:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_4_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_4_LABEL);
               }
               else {
                 thermalManager.setTargetHotend(ui.material_preset[3].hotend_temp, 0);
@@ -4053,7 +4053,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #if (PREHEAT_COUNT >= 5)
             case PREHEATHOTEND_5:
               if (draw) {
-                Draw_Menu_Item(row, ICON_Temperature, (char*)PREHEAT_5_LABEL);
+                Draw_Menu_Item(row, ICON_Temperature, PREHEAT_5_LABEL);
               }
               else {
                 thermalManager.setTargetHotend(ui.material_preset[4].hotend_temp, 0);
@@ -4063,7 +4063,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           #endif
           case PREHEATHOTEND_CUSTOM:
             if (draw) {
-              Draw_Menu_Item(row, ICON_Temperature, (char*)"Custom");
+              Draw_Menu_Item(row, ICON_Temperature, "Custom");
               Draw_Float(thermalManager.temp_hotend[0].target, row, false, 1);
             }
             else {
@@ -4072,7 +4072,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case PREHEATHOTEND_CONTINUE:
             if (draw) {
-              Draw_Menu_Item(row, ICON_SetEndTemp, (char*)"Continue");
+              Draw_Menu_Item(row, ICON_SetEndTemp, "Continue");
             }
             else {
               Popup_Handler(Heating);
@@ -4116,120 +4116,120 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
   }
 }
 
-char* CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
+const char * CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
   switch(menu) {
     case MainMenu:
-      return (char*)"Main Menu";
+      return "Main Menu";
     case Prepare:
-      return (char*)"Prepare";
+      return "Prepare";
     case HomeMenu:
-      return (char*)"Homing Menu";
+      return "Homing Menu";
     case Move:
-      return (char*)"Move";
+      return "Move";
     case ManualLevel:
-      return (char*)"Manual Leveling";
+      return "Manual Leveling";
     #if HAS_ZOFFSET_ITEM
       case ZOffset:
-        return (char*)"Z Offset";
+        return "Z Offset";
     #endif
     #if HAS_PREHEAT
       case Preheat:
-        return (char*)"Preheat";
+        return "Preheat";
     #endif
     #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
       case ChangeFilament:
-        return (char*)"Change Filament";
+        return "Change Filament";
     #endif
     case Control:
-      return (char*)"Control";
+      return "Control";
     case TempMenu:
-      return (char*)"Temperature";
+      return "Temperature";
     #if ANY(HAS_HOTEND, HAS_HEATED_BED)
       case PID:
-        return (char*)"PID Menu";
+        return "PID Menu";
     #endif
     #if HAS_HOTEND
       case HotendPID:
-        return (char*)"Hotend PID Settings";
+        return "Hotend PID Settings";
     #endif
     #if HAS_HEATED_BED
       case BedPID:
-        return (char*)"Bed PID Settings";
+        return "Bed PID Settings";
     #endif
     #if (PREHEAT_COUNT >= 1)
       case Preheat1:
-        return (char*)(PREHEAT_1_LABEL " Settings");
+        return (PREHEAT_1_LABEL " Settings");
     #endif
     #if (PREHEAT_COUNT >= 2)
       case Preheat2:
-        return (char*)(PREHEAT_2_LABEL " Settings");
+        return (PREHEAT_2_LABEL " Settings");
     #endif
     #if (PREHEAT_COUNT >= 3) 
       case Preheat3:
-        return (char*)(PREHEAT_3_LABEL " Settings");
+        return (PREHEAT_3_LABEL " Settings");
     #endif
     #if (PREHEAT_COUNT >= 4)
       case Preheat4:
-        return (char*)(PREHEAT_4_LABEL " Settings");
+        return (PREHEAT_4_LABEL " Settings");
     #endif
     #if (PREHEAT_COUNT >= 5)
       case Preheat5:
-        return (char*)(PREHEAT_5_LABEL " Settings");
+        return (PREHEAT_5_LABEL " Settings");
     #endif
     case Motion:
-      return (char*)"Motion Settings";
+      return "Motion Settings";
     case HomeOffsets:
-      return (char*)"Home Offsets";
+      return "Home Offsets";
     case MaxSpeed:
-      return (char*)"Max Speed";
+      return "Max Speed";
     case MaxAcceleration:
-      return (char*)"Max Acceleration";
+      return "Max Acceleration";
     #if HAS_CLASSIC_JERK
       case MaxJerk:
-        return (char*)"Max Jerk";
+        return "Max Jerk";
     #endif
     case Steps:
-      return (char*)"Steps/mm";
+      return "Steps/mm";
     case Visual:
-      return (char*)"Visual Settings";
+      return "Visual Settings";
     case Advanced:
-      return (char*)"Advanced Settings";
+      return "Advanced Settings";
     #if HAS_BED_PROBE
       case ProbeMenu:
-        return (char*)"Probe Menu";
+        return "Probe Menu";
     #endif
     case ColorSettings:
-      return (char*)"UI Color Settings";
+      return "UI Color Settings";
     case Info:
-      return (char*)"Info";
+      return "Info";
     case InfoMain:
-      return (char*)"Info";
+      return "Info";
     #if HAS_MESH
       case Leveling:
-        return (char*)"Leveling";
+        return "Leveling";
       case LevelView:
-        return (char*)"Mesh View";
+        return "Mesh View";
       case LevelSettings:
-        return (char*)"Leveling Settings";
+        return "Leveling Settings";
       case MeshViewer:
-        return (char*)"Mesh Viewer";
+        return "Mesh Viewer";
       case LevelManual:
-        return (char*)"Manual Tuning";
+        return "Manual Tuning";
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL) && !HAS_BED_PROBE
       case UBLMesh:
-        return (char*)"UBL Bed Leveling";
+        return "UBL Bed Leveling";
     #endif
     #if ENABLED(PROBE_MANUALLY)
       case ManualMesh:
-        return (char*)"Mesh Bed Leveling";
+        return "Mesh Bed Leveling";
     #endif
     case Tune:
-      return (char*)"Tune";
+      return "Tune";
     case PreheatHotend:
-      return (char*)"Preheat Hotend";
+      return "Preheat Hotend";
   }
-  return (char*)"";
+  return "";
 }
 
 uint8_t CrealityDWINClass::Get_Menu_Size(uint8_t menu) {
@@ -4352,52 +4352,52 @@ void CrealityDWINClass::Popup_Handler(uint8_t popupid, bool option/*=false*/) {
   popup = last_popup = popupid;
   switch (popupid) {
     case Pause:
-      Draw_Popup((char*)"Pause Print", (char*)"", (char*)"", Popup);
+      Draw_Popup("Pause Print", "", "", Popup);
       break;
     case Stop:
-      Draw_Popup((char*)"Stop Print", (char*)"", (char*)"", Popup);
+      Draw_Popup("Stop Print", "", "", Popup);
       break;
     case Resume:
-      Draw_Popup((char*)"Resume Print?", (char*)"Looks Like the last", (char*)"print was interupted.", Popup);
+      Draw_Popup("Resume Print?", "Looks Like the last", "print was interupted.", Popup);
       break;
     case ConfFilChange:
-      Draw_Popup((char*)"Confirm Filament Change", (char*)"", (char*)"", Popup);
+      Draw_Popup("Confirm Filament Change", "", "", Popup);
       break;
     case PurgeMore:
-      Draw_Popup((char*)"Purge more filament?", (char*)"(Cancel to finish process)", (char*)"", Popup);
+      Draw_Popup("Purge more filament?", "(Cancel to finish process)", "", Popup);
       break;
     case SaveLevel:
-      Draw_Popup((char*)"Leveling Complete", (char*)"Save to EEPROM?", (char*)"", Popup);
+      Draw_Popup("Leveling Complete", "Save to EEPROM?", "", Popup);
       break;
     case ETemp:
-      Draw_Popup((char*)"Nozzle is too cold", (char*)"Open Preheat Menu?", (char*)"", Popup);
+      Draw_Popup("Nozzle is too cold", "Open Preheat Menu?", "", Popup);
       break;
     case Level:
-      Draw_Popup((char*)"Auto Bed Leveling", (char*)"Please wait until done.", (char*)"", Wait, ICON_AutoLeveling);
+      Draw_Popup("Auto Bed Leveling", "Please wait until done.", "", Wait, ICON_AutoLeveling);
       break;
     case Home:
-      Draw_Popup(option ? (char*)"Parking" : (char*)"Homing", (char*)"Please wait until done.", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup(option ? "Parking" : "Homing", "Please wait until done.", "", Wait, ICON_BLTouch);
       break;
     case MoveWait:
-      Draw_Popup((char*)"Moving to Point", (char*)"Please wait until done.", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup("Moving to Point", "Please wait until done.", "", Wait, ICON_BLTouch);
       break;
     case Heating:
-      Draw_Popup((char*)"Heating", (char*)"Please wait until done.", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup("Heating", "Please wait until done.", "", Wait, ICON_BLTouch);
       break;
     case FilLoad:
-      Draw_Popup(option ? (char*)"Unloading Filament" : (char*)"Loading Filament", (char*)"Please wait until done.", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup(option ? "Unloading Filament" : "Loading Filament", "Please wait until done.", "", Wait, ICON_BLTouch);
       break;
     case FilChange:
-      Draw_Popup((char*)"Filament Change", (char*)"Please wait for prompt.", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup("Filament Change", "Please wait for prompt.", "", Wait, ICON_BLTouch);
       break;
     case TempWarn:
-      Draw_Popup(option ? (char*)"Nozzle temp too low!" : (char*)"Nozzle temp too high!", (char*)"", (char*)"", Wait, option ? ICON_TempTooLow : ICON_TempTooHigh);
+      Draw_Popup(option ? "Nozzle temp too low!" : "Nozzle temp too high!", "", "", Wait, option ? ICON_TempTooLow : ICON_TempTooHigh);
       break;
     case Runout:
-      Draw_Popup((char*)"Filament Runout", (char*)"", (char*)"", Wait, ICON_BLTouch);
+      Draw_Popup("Filament Runout", "", "", Wait, ICON_BLTouch);
       break;
     case PIDWait:
-      Draw_Popup((char*)"PID Autotune", (char*)"in process", (char*)"Please wait until done.", Wait, ICON_BLTouch);
+      Draw_Popup("PID Autotune", "in process", "Please wait until done.", Wait, ICON_BLTouch);
       break;
   }
 }
@@ -4406,39 +4406,39 @@ void CrealityDWINClass::Confirm_Handler(const char * const msg) {
   if (process != Confirm) last_process = process;
   popup = UI;
   if (strcmp_P(msg, GET_TEXT(MSG_FILAMENT_CHANGE_INSERT)) == 0) {
-    Draw_Popup((char*)"Insert Filament", (char*)"Press to Continue", (char*)"", Confirm);
+    Draw_Popup("Insert Filament", "Press to Continue", "", Confirm);
   }
   else if (strcmp_P(msg, GET_TEXT(MSG_HEATER_TIMEOUT)) == 0) {
-    Draw_Popup((char*)"Heater Timed Out", (char*)"Press to Reheat", (char*)"", Confirm);
+    Draw_Popup("Heater Timed Out", "Press to Reheat", "", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"Reheat finished.") == 0) {
-    Draw_Popup((char*)"Reheat Finished", (char*)"Press to Continue", (char*)"", Confirm);
+  else if (strcmp_P(msg, "Reheat finished.") == 0) {
+    Draw_Popup("Reheat Finished", "Press to Continue", "", Confirm);
   }
   else if (strcmp_P(msg, GET_TEXT(MSG_USERWAIT)) == 0) {
-    Draw_Popup((char*)"Waiting for Input", (char*)"Press to Continue", (char*)"", Confirm);
+    Draw_Popup("Waiting for Input", "Press to Continue", "", Confirm);
   }
   else if (strcmp_P(msg, GET_TEXT(MSG_NOZZLE_PARKED)) == 0) {
   } 
-  else if (strcmp_P(msg, (char*)"Couldn't enable Leveling") == 0) {
-    Draw_Popup((char*)"Couldn't enable Leveling", (char*)"(Valid mesh must exist)", (char*)"", Confirm);
+  else if (strcmp_P(msg, "Couldn't enable Leveling") == 0) {
+    Draw_Popup("Couldn't enable Leveling", "(Valid mesh must exist)", "", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"Invalid Mesh") == 0) {
-    Draw_Popup((char*)"Valid mesh must exist", (char*)"before tuning can be", (char*)"performed", Confirm);
+  else if (strcmp_P(msg, "Invalid Mesh") == 0) {
+    Draw_Popup("Valid mesh must exist", "before tuning can be", "performed", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"Bad extruder number") == 0) {
-    Draw_Popup((char*)"PID Autotune failed", (char*)"Bad extruder number", (char*)"", Confirm);
+  else if (strcmp_P(msg, "Bad extruder number") == 0) {
+    Draw_Popup("PID Autotune failed", "Bad extruder number", "", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"Temp too high") == 0) {
-    Draw_Popup((char*)"PID Autotune failed", (char*)"Temp too high!", (char*)"", Confirm);
+  else if (strcmp_P(msg, "Temp too high") == 0) {
+    Draw_Popup("PID Autotune failed", "Temp too high!", "", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"PID Timeout") == 0) {
-    Draw_Popup((char*)"PID Autotune failed", (char*)"Timeout!", (char*)"", Confirm);
+  else if (strcmp_P(msg, "PID Timeout") == 0) {
+    Draw_Popup("PID Autotune failed", "Timeout!", "", Confirm);
   }
-  else if (strcmp_P(msg, (char*)"PID Done") == 0) {
-    Draw_Popup((char*)"PID tuning done", (char*)"", (char*)"", Confirm);
+  else if (strcmp_P(msg, "PID Done") == 0) {
+    Draw_Popup("PID tuning done", "", "", Confirm);
   }
   else {
-    Draw_Popup(msg, (char*)"Press to Continue", (char*)"", Confirm);
+    Draw_Popup(msg, "Press to Continue", "", Confirm);
   }
 }
 
@@ -4986,9 +4986,9 @@ void CrealityDWINClass::Modify_Value(int8_t &value, float min, float max, float 
 }
 
 
-void CrealityDWINClass::Modify_Option(uint8_t value, char** options, uint8_t max) {
+void CrealityDWINClass::Modify_Option(uint8_t value, const char * const * options, uint8_t max) {
   tempvalue = value;
-  valuepointer = options;
+  valuepointer = const_cast<const char * *>(options);
   valuemin = 0;
   valuemax = max;
   process = Option;
@@ -5002,7 +5002,7 @@ void CrealityDWINClass::Update_Status(const char * const text) {
   char header[4];
   LOOP_L_N(i, 3) header[i] = text[i];
   header[3] = '\0';
-  if (strcmp_P(header,(char*)"<F>")==0) {
+  if (strcmp_P(header,"<F>")==0) {
     LOOP_L_N(i, _MIN((size_t)LONG_FILENAME_LENGTH, strlen(text))) filename[i] = text[i+3];
     filename[_MIN((size_t)LONG_FILENAME_LENGTH-1, strlen(text))] = '\0';
     Draw_Print_Filename(true);
@@ -5021,7 +5021,7 @@ void CrealityDWINClass::Start_Print(bool sd) {
     if (sd)
       strcpy_P(filename, card.longest_filename());
     else
-      strcpy_P(filename, (char*)"Host Print");
+      strcpy_P(filename, "Host Print");
     ui.set_progress(0);
     ui.set_remaining_time(0);
     Draw_Print_Screen();

--- a/Marlin/src/lcd/dwin/creality_dwin.h
+++ b/Marlin/src/lcd/dwin/creality_dwin.h
@@ -285,16 +285,16 @@ public:
     uint8_t coordinates_split_line : 4;
   } eeprom_settings;
 
-  char *color_names[11] = {(char*)"Default",(char*)"White",(char*)"Green",(char*)"Cyan",(char*)"Blue",(char*)"Magenta",(char*)"Red",(char*)"Orange",(char*)"Yellow",(char*)"Brown",(char*)"Black"};
+  const char * const color_names[11] = {"Default", "White", "Green", "Cyan", "Blue", "Magenta", "Red", "Orange", "Yellow", "Brown", "Black"};
 
 
   inline void Clear_Screen(uint8_t e=3);
   inline void Draw_Float(float value, uint8_t row, bool selected=false, uint8_t minunit=10);
-  inline void Draw_Option(uint8_t value, char** options, uint8_t row, bool selected=false, bool color=false);
+  inline void Draw_Option(uint8_t value, const char * const * options, uint8_t row, bool selected=false, bool color=false);
   inline uint16_t GetColor(uint8_t color, uint16_t original, bool light=false);
   inline void Draw_Checkbox(uint8_t row, bool value);
-  inline void Draw_Title(char* title);
-  inline void Draw_Menu_Item(uint8_t row, uint8_t icon=0, char * const label1=NULL, char * const label2=NULL, bool more=false, bool centered=false);
+  inline void Draw_Title(const char * title);
+  inline void Draw_Menu_Item(uint8_t row, uint8_t icon=0, const char * const label1=NULL, const char * const label2=NULL, bool more=false, bool centered=false);
   inline void Draw_Menu(uint8_t menu, uint8_t select=0, uint8_t scroll=0);
   inline void Redraw_Menu(bool lastselection=false, bool lastmenu=false);
   inline void Redraw_Screen();
@@ -312,7 +312,7 @@ public:
   void Draw_SD_Item(uint8_t item, uint8_t row);
   void Draw_SD_List(bool removed=false);
   void Draw_Status_Area(bool icons=false);
-  void Draw_Popup(const char *line1, const char *line2, const char *line3, uint8_t mode, uint8_t icon=0);
+  void Draw_Popup(const char * line1, const char * line2, const char * line3, uint8_t mode, uint8_t icon=0);
   void Popup_Select();
   void Update_Status_Bar(bool refresh=false);
 
@@ -321,7 +321,7 @@ public:
     void Set_Mesh_Viewer_Status();
   #endif
 
-  char* Get_Menu_Title(uint8_t menu);
+  const char * Get_Menu_Title(uint8_t menu);
   uint8_t Get_Menu_Size(uint8_t menu);
   void Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw=true);
 
@@ -347,7 +347,7 @@ public:
   void Modify_Value(int16_t &value, float min, float max, float unit, void (*f)()=NULL);
   void Modify_Value(uint32_t &value, float min, float max, float unit, void (*f)()=NULL);
   void Modify_Value(int8_t &value, float min, float max, float unit, void (*f)()=NULL);
-  void Modify_Option(uint8_t value, char** options, uint8_t max);
+  void Modify_Option(uint8_t value, const char * const * options, uint8_t max);
 
 
   void Update_Status(const char * const text);

--- a/Marlin/src/lcd/dwin/dwin.cpp
+++ b/Marlin/src/lcd/dwin/dwin.cpp
@@ -65,7 +65,7 @@ inline void DWIN_Long(size_t &i, const uint32_t lval) {
   DWIN_SendBuf[++i] = lval & 0xFF;
 }
 
-inline void DWIN_String(size_t &i, char * const string) {
+inline void DWIN_String(size_t &i, const char * const string) {
   const size_t len = _MIN(sizeof(DWIN_SendBuf) - i, strlen(string));
   memcpy(&DWIN_SendBuf[i+1], string, len);
   i += len;
@@ -255,7 +255,7 @@ void DWIN_Frame_AreaMove(uint8_t mode, uint8_t dir, uint16_t dis,
 //  x/y: Upper-left coordinate of the string
 //  *string: The string
 void DWIN_Draw_String(bool widthAdjust, bool bShow, uint8_t size,
-                      uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, char *string) {
+                      uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, const char * string) {
   size_t i = 0;
   DWIN_Byte(i, 0x11);
   // Bit 7: widthAdjust

--- a/Marlin/src/lcd/dwin/dwin.h
+++ b/Marlin/src/lcd/dwin/dwin.h
@@ -139,12 +139,12 @@ void DWIN_Frame_AreaMove(uint8_t mode, uint8_t dir, uint16_t dis,
 //  x/y: Upper-left coordinate of the string
 //  *string: The string
 void DWIN_Draw_String(bool widthAdjust, bool bShow, uint8_t size,
-                      uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, char *string);
+                      uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, const char * string);
 
 class __FlashStringHelper;
 
 inline void DWIN_Draw_String(bool widthAdjust, bool bShow, uint8_t size, uint16_t color, uint16_t bColor, uint16_t x, uint16_t y, const __FlashStringHelper *title) {
-  DWIN_Draw_String(widthAdjust, bShow, size, color, bColor, x, y, (char *)title);
+  DWIN_Draw_String(widthAdjust, bShow, size, color, bColor, x, y, title);
 }
 
 // Draw a positive integer


### PR DESCRIPTION
There is no need to cast to (char *) everywhere. Change function
signatures to accept pointer to const and remove unneeded casts.

Note that some function signatures had const pointer to non-const char
(that is, "char * const x"). This was probably meant to be non-const
pointer to const char (const char * x). I changed them to the safest
const pointer to const char (const char * const x).

This is a style refactoring. No functionality is affected, just the code is cleaned up.
