### PR TITLE
Added missing Redraw_Menu in Preheat Manager

### DIFF
--- a/Marlin/src/lcd/dwin/creality_dwin.cpp
+++ b/Marlin/src/lcd/dwin/creality_dwin.cpp
@@ -4072,6 +4072,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                     break;
                 #endif
               }
+              Redraw_Menu(true, true, true);
             }
             break;
           #if (PREHEAT_COUNT >= 1)

--- a/Marlin/src/lcd/dwin/creality_dwin.cpp
+++ b/Marlin/src/lcd/dwin/creality_dwin.cpp
@@ -4071,8 +4071,10 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
                     }
                     break;
                 #endif
+                default:
+                  Redraw_Menu(true, true, true);
+                  break;
               }
-              Redraw_Menu(true, true, true);
             }
             break;
           #if (PREHEAT_COUNT >= 1)


### PR DESCRIPTION
### Description
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
`Redraw_Menu(true, true, true);` was missing after waiting for extruder temp in the Preheat Manager for E Move
### Related Issues
This fixes #893.
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
