### PR TITLE
Update build scripts to allow proper VSCode IntelliSense functionality

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -3,12 +3,6 @@
 # Convenience script to apply customizations to CPP flags
 #
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 env.Append(CXXFLAGS=[
   "-Wno-register"
   #"-Wno-incompatible-pointer-types",

--- a/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
@@ -2,13 +2,8 @@
 # common-dependencies-post.py
 # Convenience script to add build flags for Marlin Enabled Features
 #
+
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 Import("projenv")
 
 def apply_board_build_flags():

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -2,15 +2,6 @@
 # common-dependencies.py
 # Convenience script to check dependencies and add libs and sources for Marlin Enabled Features
 #
-Import("env")
-
-#print(env.Dump())
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import subprocess,os,re
 
 PIO_VERSION_MIN = (5, 0, 3)

--- a/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+++ b/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
@@ -1,0 +1,49 @@
+#
+# copy_marlin_variant_to_framework.py
+#
+import os,shutil
+from SCons.Script import DefaultEnvironment
+from platformio import util
+from platformio.package.meta import PackageSpec
+
+def copytree(src, dst, symlinks=False, ignore=None):
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, symlinks, ignore)
+        else:
+            shutil.copy2(s, d)
+
+env = DefaultEnvironment()
+platform = env.PioPlatform()
+board = env.BoardConfig()
+variant = board.get("build.variant")
+
+platform_packages = env.GetProjectOption('platform_packages')
+# if there's no framework defined, take it from the class name of platform
+framewords = {
+    "Ststm32Platform": "framework-arduinoststm32",
+    "AtmelavrPlatform": "framework-arduino-avr"
+}
+if len(platform_packages) == 0:
+    platform_name = framewords[platform.__class__.__name__]
+else:
+    platform_name = PackageSpec(platform_packages[0]).name
+
+FRAMEWORK_DIR = platform.get_package_dir(platform_name)
+assert os.path.isdir(FRAMEWORK_DIR)
+assert os.path.isdir("buildroot/share/PlatformIO/variants")
+
+variant_dir = os.path.join(FRAMEWORK_DIR, "variants", variant)
+
+source_dir = os.path.join("buildroot/share/PlatformIO/variants", variant)
+assert os.path.isdir(source_dir)
+
+if os.path.isdir(variant_dir):
+    shutil.rmtree(variant_dir)
+
+if not os.path.isdir(variant_dir):
+    os.mkdir(variant_dir)
+
+copytree(source_dir, variant_dir)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,14 +2,8 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import os,re,sys
+Import("env")
 
 def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:


### PR DESCRIPTION
Spent the last few hours tearing my hair out trying to figure out why VSCode could flawlessly build a detailed c_cpp_properties.json for the base Marlin repo (and have proper IntelliSense as a result), but opening Jyers repo would cause VSCode to fallback to a default c_cpp_properties.json with no toolchain, include dirs or build flags (rendering IntelliSense incapable of providing error checking and causing hundreds of erroneous syntax errors in VSCode).  59fd6428ae77a153082d8e1dd49c081b79a81a93 is the only commit related to build-scripts that isn't already merged into this branch, so I tried simply cherry-picking the commit into the latest JyersUI branch and low and behold VSCode flawlessly built a c_cpp_properties.json file with defines, headers, includes, and a proper compiler path.

The code to skip the build scripts was added here https://github.com/MarlinFirmware/Marlin/pull/21643, but as far as I can tell, the PlatformIO-related issue that it was intended to workaround has since been patched, as I do not see any long JS console messages with the updated build scripts (and the main Marlin repo has since removed this code, hence the cherry-pick). Further discussion of why this change was reverted can be found here: https://github.com/MarlinFirmware/Marlin/pull/21657

Anyone using VSCode (especially on Windows) and trying to work on Jyers firmware would probably appreciate this being cherrypicked over so that they too can have IntelliSense that actually knows what it's doing.