### PR TITLE
REVERSE_ENCODER_DIRECTION patch

### DIFF
--- a/Marlin/src/lcd/e3v2/creality/rotary_encoder.cpp
+++ b/Marlin/src/lcd/e3v2/creality/rotary_encoder.cpp
@@ -122,8 +122,13 @@ ENCODER_DiffState Encoder_ReceiveAnalyze() {
   }
 
   if (ABS(temp_diff) >= ENCODER_PULSES_PER_STEP) {
-    if (temp_diff > 0) temp_diffState = ENCODER_DIFF_CW;
-    else temp_diffState = ENCODER_DIFF_CCW;
+    #if ENABLED(REVERSE_ENCODER_DIRECTION)
+      if (temp_diff > 0) temp_diffState = ENCODER_DIFF_CCW;
+      else temp_diffState = ENCODER_DIFF_CW;
+    #else
+      if (temp_diff > 0) temp_diffState = ENCODER_DIFF_CW;
+      else temp_diffState = ENCODER_DIFF_CCW;
+    #endif
 
     #if ENABLED(ENCODER_RATE_MULTIPLIER)
 


### PR DESCRIPTION
Changed rotary_encoder.cpp to enable the use of REVERSE_ENCODER_DIRECTION. If Makro is uncommented, encoder direction is now reversed.
This PR contains changes to rotary_encoder.cpp. With these changes the makro REVERSE_ENCODER_DIRECTION can now successfully be used to reverse the encoder direction.

Benefits

Adding the functionality of the makro again. This is the first place I looked to change the direction after replacing my encoder because the old had broken.
Configurations

To test the pr simply (un)comment "#define REVERSE_ENCODER_DIRECTION" in the Configuration.h

Related Issues

Another user had this problem in issue Jyers#736