### PR TITLE
Raise Z to safe homing height before probe assisted leveling

### DIFF
--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -1516,6 +1516,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               Draw_Checkbox(row, use_probe);
               if (use_probe) {
                 Popup_Handler(Level);
+                do_z_clearance(Z_HOMING_HEIGHT);
                 corner_avg = 0;
                 #define PROBE_X_MIN _MAX(0 + corner_pos, X_MIN_POS + probe.offset.x, X_MIN_POS + PROBING_MARGIN) - probe.offset.x
                 #define PROBE_X_MAX _MIN((X_BED_SIZE + X_MIN_POS) - corner_pos, X_MAX_POS + probe.offset.x, X_MAX_POS - PROBING_MARGIN) - probe.offset.x


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Previously, if the nozzle was at bed height (ie. manually leveling with sheet of paper) and "Use Probe" was pressed, the hotend would be moved directly to the first probe position without raising the z-axis, potentially causing damage to the bed. 

My change raises the z axis to at least Z_HOMING_HEIGHT (used by G28 when homing XY) before starting the probing sequence.

### Benefits

See above

### Configurations

### Related Issues
